### PR TITLE
Add Buy and Sell helper in negotiation

### DIFF
--- a/src/blockchains/bitcoin.rs
+++ b/src/blockchains/bitcoin.rs
@@ -13,7 +13,8 @@ use crate::blockchains::{Blockchain, Fee, FixeFee};
 use crate::crypto::{Crypto, ECDSAScripts, TrSchnorrScripts};
 use crate::roles::Arbitrating;
 
-pub struct Bitcoin {}
+#[derive(Clone, Copy)]
+pub struct Bitcoin;
 
 impl Blockchain for Bitcoin {
     /// Type for the traded asset unit
@@ -41,6 +42,7 @@ impl Blockchain for Bitcoin {
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct SatPerVByte(Amount);
 
 impl SatPerVByte {

--- a/src/blockchains/mod.rs
+++ b/src/blockchains/mod.rs
@@ -8,9 +8,9 @@ pub mod bitcoin;
 pub mod monero;
 
 /// Base trait for defining a blockchain and its asset type.
-pub trait Blockchain {
+pub trait Blockchain: Copy {
     /// Type for the traded asset unit
-    type AssetUnit;
+    type AssetUnit: Copy;
 
     /// Type of the blockchain identifier
     type Id: FromStr + Into<String>;
@@ -26,6 +26,18 @@ pub trait Blockchain {
 
     /// Create a new blockchain
     fn new() -> Self;
+
+    /// Return if the blockchain implements the Arbitrating role
+    /// Default: false
+    fn can_play_arbitrating_role(&self) -> bool {
+        false
+    }
+
+    /// Return if the blockchain implements the Accordant role
+    /// Default: false
+    fn can_play_accordant_role(&self) -> bool {
+        false
+    }
 }
 
 /// Enable fee calculation for a blockchain.
@@ -38,7 +50,7 @@ where
     S: FeeStrategy,
 {
     /// Type for describing the fees of a blockchain
-    type FeeUnit;
+    type FeeUnit: Copy;
 
     /// Calculates and sets the fees on the given transaction and return the fees set
     fn set_fees(tx: &mut Self::Transaction, strategy: &S) -> Self::FeeUnit;
@@ -54,9 +66,10 @@ where
 ///
 /// A fee strategy is included in an offer, so Alice and Bob can verify that transaction are valid
 /// uppon reception by the other participant.
-pub trait FeeStrategy {}
+pub trait FeeStrategy: Copy {}
 
 /// A static fee strategy. Sets a fixe fee on every transactions.
+#[derive(Clone, Copy)]
 pub struct FixeFee<B>(B::FeeUnit)
 where
     B: Fee<Self> + ?Sized;
@@ -75,6 +88,7 @@ impl<B> FeeStrategy for FixeFee<B> where B: Fee<Self> + ?Sized {}
 
 /// A range strategy for setting transactions' fees. Build from lower and upper bounds, the fee on
 /// the transaction MUST be within the bounds, lower and upper inclusive.
+#[derive(Clone, Copy)]
 pub struct RangeFee<B>(B::FeeUnit, B::FeeUnit)
 where
     B: Fee<Self> + ?Sized;

--- a/src/blockchains/monero.rs
+++ b/src/blockchains/monero.rs
@@ -8,7 +8,8 @@ use monero::util::key::PublicKey;
 use crate::blockchains::Blockchain;
 use crate::roles::Accordant;
 
-pub struct Monero {}
+#[derive(Clone, Copy)]
+pub struct Monero;
 
 impl Blockchain for Monero {
     /// Type for the traded asset unit

--- a/src/negotiation.rs
+++ b/src/negotiation.rs
@@ -36,6 +36,200 @@ where
     pub maker_role: SwapRole,
 }
 
+/// Helper to create an offer from an arbitrating asset buyer perspective.
+///
+/// **This helper works only for buying Arbitrating assets with some Accordant assets**. The
+/// reverse is not implemented for the `Buy` helper. You should use the `Sell` helper.
+pub struct Buy<T, U, S, N>(BuilderState<T, U, S, N>)
+where
+    T: Arbitrating + Fee<S>,
+    U: Accordant,
+    S: FeeStrategy,
+    N: Network;
+
+impl<T, U, S, N> Buy<T, U, S, N>
+where
+    T: Arbitrating + Fee<S>,
+    U: Accordant,
+    S: FeeStrategy,
+    N: Network,
+{
+    /// Defines the asset and its amount the maker will receive in exchange of the asset and amount
+    /// defined in the `with` method.
+    pub fn some(asset: T, amount: T::AssetUnit) -> Self {
+        let mut buy = Self(BuilderState::default());
+        buy.0.arbitrating = Some(asset);
+        buy.0.arbitrating_assets = Some(amount);
+        buy
+    }
+
+    /// Defines the asset and its amount the maker will send to get the assets defined in the
+    /// `some` method.
+    pub fn with(&mut self, asset: U, amount: U::AssetUnit) -> &Self {
+        self.0.accordant = Some(asset);
+        self.0.accordant_assets = Some(amount);
+        self
+    }
+
+    /// Sets the timelocks for the proposed offer
+    pub fn with_timelocks(&mut self, cancel: T::Timelock, punish: T::Timelock) -> &Self {
+        self.0.cancel_timelock = Some(cancel);
+        self.0.punish_timelock = Some(punish);
+        self
+    }
+
+    /// Sets the fee strategy for the proposed offer
+    pub fn with_fee(&mut self, strategy: S) -> &Self {
+        self.0.fee_strategy = Some(strategy);
+        self
+    }
+
+    /// Sets the network for the proposed offer
+    pub fn on(&mut self, network: N) -> &Self {
+        self.0.network = Some(network);
+        self
+    }
+
+    /// Transform the internal state into an offer if all parameters have been set properly,
+    /// otherwise return `None`.
+    ///
+    /// This function automatically sets the maker swap role as **Alice** to comply with the buy
+    /// contract.
+    pub fn to_offer(&mut self) -> Option<Offer<T, U, S, N>> {
+        self.0.maker_role = Some(SwapRole::Alice);
+        Some(Offer {
+            network: self.0.network?,
+            arbitrating: self.0.arbitrating?,
+            accordant: self.0.accordant?,
+            arbitrating_assets: self.0.arbitrating_assets?,
+            accordant_assets: self.0.accordant_assets?,
+            cancel_timelock: self.0.cancel_timelock?,
+            punish_timelock: self.0.punish_timelock?,
+            fee_strategy: self.0.fee_strategy?,
+            maker_role: self.0.maker_role?,
+        })
+    }
+}
+
+/// Helper to create an offer from an arbitrating asset seller perspective.
+///
+/// **This helper works only for selling Arbitrating assets for some Accordant assets**. The
+/// reverse is not implemented for the `Sell` helper. You should use the `Buy` helper.
+pub struct Sell<T, U, S, N>(BuilderState<T, U, S, N>)
+where
+    T: Arbitrating + Fee<S>,
+    U: Accordant,
+    S: FeeStrategy,
+    N: Network;
+
+impl<T, U, S, N> Sell<T, U, S, N>
+where
+    T: Arbitrating + Fee<S>,
+    U: Accordant,
+    S: FeeStrategy,
+    N: Network,
+{
+    /// Defines the asset and its amount the maker will send to get the assets defined in the
+    /// `for_some` method.
+    pub fn some(asset: T, amount: T::AssetUnit) -> Self {
+        let mut buy = Self(BuilderState::default());
+        buy.0.arbitrating = Some(asset);
+        buy.0.arbitrating_assets = Some(amount);
+        buy
+    }
+
+    /// Defines the asset and its amount the maker will receive in exchange of the asset and amount
+    /// defined in the `some` method.
+    pub fn for_some(&mut self, asset: U, amount: U::AssetUnit) -> &Self {
+        self.0.accordant = Some(asset);
+        self.0.accordant_assets = Some(amount);
+        self
+    }
+
+    /// Sets the timelocks for the proposed offer
+    pub fn with_timelocks(&mut self, cancel: T::Timelock, punish: T::Timelock) -> &Self {
+        self.0.cancel_timelock = Some(cancel);
+        self.0.punish_timelock = Some(punish);
+        self
+    }
+
+    /// Sets the fee strategy for the proposed offer
+    pub fn with_fee(&mut self, strategy: S) -> &Self {
+        self.0.fee_strategy = Some(strategy);
+        self
+    }
+
+    /// Sets the network for the proposed offer
+    pub fn on(&mut self, network: N) -> &Self {
+        self.0.network = Some(network);
+        self
+    }
+
+    /// Transform the internal state into an offer if all parameters have been set properly,
+    /// otherwise return `None`.
+    ///
+    /// This function automatically sets the maker swap role as **Bob** to comply with the buy
+    /// contract.
+    pub fn to_offer(&mut self) -> Option<Offer<T, U, S, N>> {
+        self.0.maker_role = Some(SwapRole::Bob);
+        Some(Offer {
+            network: self.0.network?,
+            arbitrating: self.0.arbitrating?,
+            accordant: self.0.accordant?,
+            arbitrating_assets: self.0.arbitrating_assets?,
+            accordant_assets: self.0.accordant_assets?,
+            cancel_timelock: self.0.cancel_timelock?,
+            punish_timelock: self.0.punish_timelock?,
+            fee_strategy: self.0.fee_strategy?,
+            maker_role: self.0.maker_role?,
+        })
+    }
+}
+
+// Internal state of an offer builder
+struct BuilderState<Ar, Ac, S, N>
+where
+    Ar: Arbitrating + Fee<S>,
+    Ac: Accordant,
+    S: FeeStrategy,
+    N: Network,
+{
+    network: Option<N>,
+    arbitrating: Option<Ar>,
+    accordant: Option<Ac>,
+    arbitrating_assets: Option<Ar::AssetUnit>,
+    accordant_assets: Option<Ac::AssetUnit>,
+    cancel_timelock: Option<Ar::Timelock>,
+    punish_timelock: Option<Ar::Timelock>,
+    fee_strategy: Option<S>,
+    maker_role: Option<SwapRole>,
+}
+
+impl<Ar, Ac, S, N> Default for BuilderState<Ar, Ac, S, N>
+where
+    Ar: Arbitrating + Fee<S>,
+    Ac: Accordant,
+    S: FeeStrategy,
+    N: Network,
+{
+    fn default() -> BuilderState<Ar, Ac, S, N> {
+        BuilderState {
+            network: None,
+            arbitrating: None,
+            accordant: None,
+            arbitrating_assets: None,
+            accordant_assets: None,
+            cancel_timelock: None,
+            punish_timelock: None,
+            fee_strategy: None,
+            maker_role: None,
+        }
+    }
+}
+
+/// A public offer is shared across maker's prefered network to signal is willing of trading some
+/// assets at some conditions. The assets and condition are defined in the offer, the make peer
+/// connection information are happen to the offer the create a public offer.
 pub struct PublicOffer<Ar, Ac, S, N>
 where
     Ar: Arbitrating + Fee<S>,
@@ -49,7 +243,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::Offer;
+    use super::{Buy, Offer, Sell};
     use crate::blockchains::{
         bitcoin::Bitcoin, bitcoin::SatPerVByte, monero::Monero, Blockchain, FixeFee,
     };
@@ -69,5 +263,30 @@ mod tests {
             fee_strategy: FixeFee::new(SatPerVByte::from_sat(20)),
             maker_role: SwapRole::Alice,
         };
+    }
+
+    #[test]
+    fn maker_buy_arbitrating_assets_offer() {
+        let mut buy = Buy::some(Bitcoin::new(), Amount::from_sat(100000));
+        buy.with(Monero::new(), 200);
+        buy.with_timelocks(10, 10);
+        buy.with_fee(FixeFee::new(SatPerVByte::from_sat(20)));
+        buy.on(Local);
+        assert!(buy.to_offer().is_some());
+        assert_eq!(
+            buy.to_offer().expect("an offer").maker_role,
+            SwapRole::Alice
+        );
+    }
+
+    #[test]
+    fn maker_sell_arbitrating_assets_offer() {
+        let mut sell = Sell::some(Bitcoin::new(), Amount::from_sat(100000));
+        sell.for_some(Monero::new(), 200);
+        sell.with_timelocks(10, 10);
+        sell.with_fee(FixeFee::new(SatPerVByte::from_sat(20)));
+        sell.on(Local);
+        assert!(sell.to_offer().is_some());
+        assert_eq!(sell.to_offer().expect("an offer").maker_role, SwapRole::Bob);
     }
 }

--- a/src/roles.rs
+++ b/src/roles.rs
@@ -3,19 +3,22 @@
 use crate::blockchains::Blockchain;
 
 /// Three network that need to be defined for every blockchains
-pub trait Network {}
+pub trait Network: Copy {}
 
 /// Mainnet works with real assets
+#[derive(Clone, Copy)]
 pub struct Mainnet;
 
 impl Network for Mainnet {}
 
 /// Testnet works with decentralized testing network for both chains
+#[derive(Clone, Copy)]
 pub struct Testnet;
 
 impl Network for Testnet {}
 
 /// Local works with local blockchains for both chains
+#[derive(Clone, Copy)]
 pub struct Local;
 
 impl Network for Local {}
@@ -31,6 +34,7 @@ pub struct Taker;
 
 pub trait Role {}
 
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SwapRole {
     Alice,
     Bob,
@@ -57,7 +61,12 @@ pub trait Arbitrating: Blockchain {
     type Transaction;
 
     //// Defines the type of timelock used for the arbitrating transactions
-    type Timelock;
+    type Timelock: Copy;
+
+    /// Return if the blockchain implements the Arbitrating role, returns true
+    fn can_play_arbitrating_role(&self) -> bool {
+        true
+    }
 }
 
 pub trait Accordant: Blockchain {
@@ -69,4 +78,9 @@ pub trait Accordant: Blockchain {
 
     /// Commitment type for the blockchain
     type Commitment;
+
+    /// Return if the blockchain implements the Accordant role, returns true
+    fn can_play_accordant_role(&self) -> bool {
+        true
+    }
 }


### PR DESCRIPTION
`Buy` and `Sell` help to create `Offer`s in an easy and convenient way. They are used by the `maker` and are design based on buying and selling arbitrating assets for accordant ones.