### PR TITLE
Negotiation public offer serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2018"
 
 [dependencies]
 bitcoin = "0.26.0"
+hex = "0.4.3"
 monero = "0.10.0"
 secp256k1 = { version = "0.20.1", features = ["rand-std"] }
 curve25519-dalek = "3.0.0"
 rand_core = { version = "^0.5.0", features = ["getrandom"] }
-
+thiserror = "1.0.24"
 
 [dev-dependencies]
-hex = "0.4.2"
 bitcoincore-rpc = "0.13.0"

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -2,7 +2,6 @@
 
 use bitcoin::blockdata::transaction::TxOut;
 use bitcoin::hash_types::PubkeyHash;
-//use bitcoin::network::constants::Network;
 use bitcoin::secp256k1::SerializedSignature;
 use bitcoin::util::address::Address;
 use bitcoin::util::amount::Amount;
@@ -26,24 +25,6 @@ pub struct Bitcoin;
 impl Blockchain for Bitcoin {
     /// Type for the traded asset unit
     type AssetUnit = Amount;
-
-    //type Network = Network;
-
-    ///// Type of the blockchain identifier
-    //type Id = String;
-
-    ///// Type of the chain identifier
-    //type ChainId = Network;
-
-    ///// Returns the blockchain identifier
-    //fn id(&self) -> String {
-    //    String::from("btc")
-    //}
-
-    ///// Returns the chain identifier
-    //fn chain_id(&self) -> Network {
-    //    Network::Bitcoin
-    //}
 
     /// Create a new Bitcoin blockchain
     fn new() -> Self {

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -8,10 +8,12 @@ use bitcoin::util::address::Address;
 use bitcoin::util::amount::Amount;
 use bitcoin::util::key::{PrivateKey, PublicKey};
 use bitcoin::util::psbt::PartiallySignedTransaction;
+use std::io;
 
 use crate::blockchain::{
     Blockchain, Fee, FeePolitic, FeeStrategy, FeeStrategyError, FeeUnit, Onchain,
 };
+use crate::consensus::{self, Decodable, Encodable};
 use crate::crypto::{Commitment, CrossGroupDLEQ, Curve, ECDSAScripts, Keys, Script, Signatures};
 use crate::monero::{Ed25519, Monero};
 use crate::role::Arbitrating;
@@ -47,6 +49,36 @@ impl Blockchain for Bitcoin {
     fn new() -> Self {
         Bitcoin {}
     }
+
+    fn from_u32(bytes: u32) -> Option<Self> {
+        match bytes {
+            0x80000000 => Some(Self::new()),
+            _ => None,
+        }
+    }
+
+    fn to_u32(&self) -> u32 {
+        0x80000000
+    }
+}
+
+impl Encodable for Amount {
+    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+        // 64 bits value
+        8u8.consensus_encode(writer)?;
+        bitcoin::consensus::encode::Encodable::consensus_encode(&self.as_sat(), writer)
+    }
+}
+
+impl Decodable for Amount {
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        let len: u8 = Decodable::consensus_decode(d)?;
+        // 64 bits value
+        debug_assert_eq!(len, 8);
+        let sats: u64 = bitcoin::consensus::encode::Decodable::consensus_decode(d)
+            .map_err(|_| consensus::Error::ParseFailed("Bitcoin amount parsing failed"))?;
+        Ok(Amount::from_sat(sats))
+    }
 }
 
 #[derive(Clone, PartialOrd, PartialEq)]
@@ -66,40 +98,15 @@ impl SatPerVByte {
     }
 }
 
-#[derive(Clone)]
-pub enum FeeStrategies {
-    Fixed(SatPerVByte),
-    Range(std::ops::Range<SatPerVByte>),
-}
-
-impl FeeUnit for FeeStrategies {
+impl FeeUnit for Bitcoin {
     type FeeUnit = SatPerVByte;
 }
 
-impl FeeStrategy for FeeStrategies {
-    fn fixed_fee(fee: Self::FeeUnit) -> Self {
-        FeeStrategies::Fixed(fee)
-    }
-
-    fn range_fee(fee_low: Self::FeeUnit, fee_high: Self::FeeUnit) -> Self {
-        if fee_low > fee_high {
-            FeeStrategies::Fixed(fee_high)
-        } else {
-            FeeStrategies::Range(std::ops::Range {
-                start: fee_low,
-                end: fee_high,
-            })
-        }
-    }
-}
-
 impl Fee for Bitcoin {
-    type FeeStrategy = FeeStrategies;
-
     /// Calculates and sets the fees on the given transaction and return the fees set
     fn set_fees(
         tx: &mut PartiallySignedTransaction,
-        strategy: &FeeStrategies,
+        strategy: &FeeStrategy<SatPerVByte>,
         politic: FeePolitic,
     ) -> Result<Amount, FeeStrategyError> {
         // Get the available amount on the transaction
@@ -121,10 +128,8 @@ impl Fee for Bitcoin {
 
         // Compute the fee amount to set in total
         let fee_amount = match strategy {
-            FeeStrategies::Fixed(sat_per_vbyte) => {
-                sat_per_vbyte.as_native_unit().checked_mul(weight)
-            }
-            FeeStrategies::Range(range) => match politic {
+            FeeStrategy::Fixed(sat_per_vbyte) => sat_per_vbyte.as_native_unit().checked_mul(weight),
+            FeeStrategy::Range(range) => match politic {
                 FeePolitic::Aggressive => range.start.as_native_unit().checked_mul(weight),
                 FeePolitic::Conservative => range.end.as_native_unit().checked_mul(weight),
             },
@@ -148,7 +153,7 @@ impl Fee for Bitcoin {
     /// Validates that the fees for the given transaction are set accordingly to the strategy
     fn validate_fee(
         _tx: &PartiallySignedTransaction,
-        _strategy: &FeeStrategies,
+        _strategy: &FeeStrategy<SatPerVByte>,
         _politic: FeePolitic,
     ) -> Result<bool, FeeStrategyError> {
         todo!()
@@ -160,7 +165,39 @@ impl Arbitrating for Bitcoin {
     type Address = Address;
 
     /// Defines the type of timelock used for the arbitrating transactions
-    type Timelock = u32;
+    type Timelock = CSVTimelock;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct CSVTimelock(u32);
+
+impl CSVTimelock {
+    pub fn new(timelock: u32) -> Self {
+        Self(timelock)
+    }
+
+    pub fn as_u32(&self) -> u32 {
+        self.0
+    }
+}
+
+impl Encodable for CSVTimelock {
+    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+        // 32 bits value
+        4u8.consensus_encode(writer)?;
+        bitcoin::consensus::encode::Encodable::consensus_encode(&self.0, writer)
+    }
+}
+
+impl Decodable for CSVTimelock {
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        let len: u8 = Decodable::consensus_decode(d)?;
+        // 32 bits value
+        debug_assert_eq!(len, 4);
+        let timelock: u32 = bitcoin::consensus::encode::Decodable::consensus_decode(d)
+            .map_err(|_| consensus::Error::ParseFailed("Bitcoin u32 timelock parsing failed"))?;
+        Ok(CSVTimelock(timelock))
+    }
 }
 
 impl Onchain for Bitcoin {

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -2,7 +2,7 @@
 
 use bitcoin::blockdata::transaction::TxOut;
 use bitcoin::hash_types::PubkeyHash;
-use bitcoin::network::constants::Network;
+//use bitcoin::network::constants::Network;
 use bitcoin::secp256k1::SerializedSignature;
 use bitcoin::util::address::Address;
 use bitcoin::util::amount::Amount;
@@ -25,7 +25,7 @@ impl Blockchain for Bitcoin {
     /// Type for the traded asset unit
     type AssetUnit = Amount;
 
-    type Network = Network;
+    //type Network = Network;
 
     ///// Type of the blockchain identifier
     //type Id = String;

--- a/src/bitcoin/transaction/mod.rs
+++ b/src/bitcoin/transaction/mod.rs
@@ -5,7 +5,7 @@ use bitcoin::blockdata::opcodes;
 use bitcoin::blockdata::script::{Builder, Script};
 use bitcoin::blockdata::transaction::{OutPoint, SigHashType, TxIn, TxOut};
 use bitcoin::hashes::sha256d::Hash;
-use bitcoin::network::constants::Network;
+use bitcoin::network::constants::Network as BtcNetwork;
 use bitcoin::secp256k1::{Message, Secp256k1, SerializedSignature, Signing};
 use bitcoin::util::address::{self, Address};
 use bitcoin::util::bip143::SigHashCache;
@@ -13,7 +13,7 @@ use bitcoin::util::key::{PrivateKey, PublicKey};
 use bitcoin::util::psbt::{self, PartiallySignedTransaction};
 
 use crate::bitcoin::{Bitcoin, FeeStrategies, PDLEQ};
-use crate::blockchain::{Fee, FeePolitic, FeeStrategyError};
+use crate::blockchain::{Fee, FeePolitic, FeeStrategyError, Network};
 use crate::script;
 use crate::transaction::{
     AdaptorSignable, Broadcastable, Buyable, Cancelable, Failable, Forkable, Fundable, Linkable,
@@ -110,7 +110,11 @@ impl Fundable<Bitcoin> for Funding {
     }
 
     fn get_address(&self, network: Network) -> Result<Address, Error> {
-        Ok(Address::p2wpkh(&self.pubkey, network)?)
+        match network {
+            Network::Mainnet => Ok(Address::p2wpkh(&self.pubkey, BtcNetwork::Bitcoin)?),
+            Network::Testnet => Ok(Address::p2wpkh(&self.pubkey, BtcNetwork::Testnet)?),
+            Network::Local => Ok(Address::p2wpkh(&self.pubkey, BtcNetwork::Regtest)?),
+        }
     }
 
     fn update(&mut self, args: bitcoin::blockdata::transaction::Transaction) -> Result<(), Error> {

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -1,24 +1,12 @@
-//! Defines what a blockchain is and what needs to be implemented
+//! Defines the interface a blockchain must implement
+//!
+//! A blockchain must identify the block chain (or equivalent), e.g. with the genesis hash, and the
+//! asset, e.g. for Etherum blockchain assets can be eth or dai.
 
 /// Base trait for defining a blockchain and its asset type.
 pub trait Blockchain: Copy {
     /// Type for the traded asset unit
     type AssetUnit: Copy;
-
-    /// Type of the network for the blockchain
-    type Network;
-
-    ///// Type of the blockchain identifier
-    //type Id: FromStr + Into<String>;
-
-    ///// Type of the chain identifier
-    //type ChainId;
-
-    ///// Returns the blockchain identifier
-    //fn id(&self) -> Self::Id;
-
-    ///// Returns the chain identifier
-    //fn chain_id(&self) -> Self::ChainId;
 
     /// Create a new blockchain
     fn new() -> Self;
@@ -97,23 +85,14 @@ pub trait Fee: Onchain + Blockchain {
     ) -> Result<bool, FeeStrategyError>;
 }
 
-/// Defines a blockchain network, identifies how to interact with the blockchain.
-pub trait Network: Copy {}
-
-/// Mainnet works with real assets.
-#[derive(Clone, Copy)]
-pub struct Mainnet;
-
-impl Network for Mainnet {}
-
-/// Testnet works with decentralized testing network, assets have no value.
-#[derive(Clone, Copy)]
-pub struct Testnet;
-
-impl Network for Testnet {}
-
-/// Local works with local copy, auto-generated blockchains, assets have no value.
-#[derive(Clone, Copy)]
-pub struct Local;
-
-impl Network for Local {}
+/// Defines a blockchain network, identifies in which context the system interacts with the
+/// blockchain.
+#[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Debug)]
+pub enum Network {
+    /// Represents a real asset on his valuable network
+    Mainnet,
+    /// Represents non-valuable assets on test networks
+    Testnet,
+    /// Local and private testnets
+    Local,
+}

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,0 +1,192 @@
+use hex::encode as hex_encode;
+use thiserror::Error;
+
+use std::io;
+use std::io::prelude::*;
+
+/// Encoding error
+#[derive(Error, Debug)]
+pub enum Error {
+    /// The type is not defined in the consensus
+    #[error("Unknown consensus type")]
+    UnknownType,
+    /// And I/O error
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+    /// Parsing error
+    #[error("Parsing error: {0}")]
+    ParseFailed(&'static str),
+}
+
+/// Encode an object into a vector
+pub fn serialize<T: Encodable + std::fmt::Debug + ?Sized>(data: &T) -> Vec<u8> {
+    let mut encoder = Vec::new();
+    let len = data.consensus_encode(&mut encoder).unwrap();
+    debug_assert_eq!(len, encoder.len());
+    encoder
+}
+
+/// Encode an object into a hex-encoded string
+pub fn serialize_hex<T: Encodable + std::fmt::Debug + ?Sized>(data: &T) -> String {
+    hex_encode(serialize(data))
+}
+
+/// Deserialize an object from a vector, will error if said deserialization
+/// doesn't consume the entire vector.
+pub fn deserialize<T: Decodable>(data: &[u8]) -> Result<T, Error> {
+    let (rv, consumed) = deserialize_partial(data)?;
+
+    // Fail if data are not consumed entirely.
+    if consumed == data.len() {
+        Ok(rv)
+    } else {
+        Err(Error::ParseFailed(
+            "data not consumed entirely when explicitly deserializing",
+        ))
+    }
+}
+
+/// Deserialize an object from a vector, but will not report an error if said deserialization
+/// doesn't consume the entire vector.
+pub fn deserialize_partial<T: Decodable>(data: &[u8]) -> Result<(T, usize), Error> {
+    let mut decoder = io::Cursor::new(data);
+    let rv = Decodable::consensus_decode(&mut decoder)?;
+    let consumed = decoder.position() as usize;
+
+    Ok((rv, consumed))
+}
+
+/// Data which can be encoded in a consensus-consistent way
+pub trait Encodable {
+    /// Encode an object with a well-defined format, should only ever error if
+    /// the underlying encoder errors.
+    ///
+    /// The only errors returned are errors propagated from the writer.
+    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error>;
+}
+
+/// Data which can be encoded in a consensus-consistent way
+pub trait Decodable: Sized {
+    /// Decode an object with a well-defined format
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, Error>;
+}
+
+impl Encodable for Vec<u8> {
+    #[inline]
+    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+        if self.len() > u8::MAX as usize {
+            return Err(io::Error::new(io::ErrorKind::Other, "Value is too long"));
+        }
+        (self.len() as u8).consensus_encode(s)?;
+        s.write_all(&self[..])?;
+        Ok(self.len() + 1)
+    }
+}
+
+impl Decodable for Vec<u8> {
+    #[inline]
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, Error> {
+        let len = u8::consensus_decode(d)?;
+        if len > u8::MAX {
+            return Err(Error::ParseFailed("Vec is too long"));
+        }
+        let mut ret = Vec::<u8>::with_capacity(len as usize);
+        for _ in 0..len {
+            ret.push(Decodable::consensus_decode(d)?);
+        }
+        Ok(ret)
+    }
+}
+
+impl Encodable for u8 {
+    #[inline]
+    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+        s.write_all(&self.to_le_bytes())?;
+        Ok(1)
+    }
+}
+
+impl Decodable for u8 {
+    #[inline]
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, Error> {
+        let mut buffer = [0u8; 1];
+        d.read_exact(&mut buffer)?;
+        Ok(u8::from_le_bytes(buffer))
+    }
+}
+
+impl Encodable for u16 {
+    #[inline]
+    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+        s.write_all(&self.to_le_bytes())?;
+        Ok(2)
+    }
+}
+
+impl Decodable for u16 {
+    #[inline]
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, Error> {
+        let mut buffer = [0u8; 2];
+        d.read_exact(&mut buffer)?;
+        Ok(u16::from_le_bytes(buffer))
+    }
+}
+
+impl Encodable for u32 {
+    #[inline]
+    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+        s.write_all(&self.to_le_bytes())?;
+        Ok(4)
+    }
+}
+
+impl Decodable for u32 {
+    #[inline]
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, Error> {
+        let mut buffer = [0u8; 4];
+        d.read_exact(&mut buffer)?;
+        Ok(u32::from_le_bytes(buffer))
+    }
+}
+
+impl Encodable for u64 {
+    #[inline]
+    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+        s.write_all(&self.to_le_bytes())?;
+        Ok(8)
+    }
+}
+
+impl Decodable for u64 {
+    #[inline]
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, Error> {
+        let mut buffer = [0u8; 8];
+        d.take(8).read(&mut buffer)?;
+        Ok(u64::from_le_bytes(buffer))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn little_endianness_test() {
+        assert_eq!(&[0xef, 0xbe, 0xad, 0xde], &serialize(&0xdeadbeefu32)[..]);
+        assert_eq!(
+            deserialize::<u32>(&[0xef, 0xbe, 0xad, 0xde]).unwrap(),
+            0xdeadbeef
+        );
+        assert_eq!(&[0x01], &serialize(&0x01u8)[..]);
+        assert_eq!(deserialize::<u8>(&[0x01]).unwrap(), 0x01);
+    }
+
+    #[test]
+    fn simple_vec() {
+        let vec = vec![0xde, 0xad, 0xbe, 0xef];
+        assert_eq!(serialize_hex(&vec), "04deadbeef");
+        // test max size vec
+        let vec = vec![0x41; 255];
+        assert_eq!(deserialize::<Vec<u8>>(&serialize(&vec)[..]).unwrap(), vec);
+    }
+}

--- a/src/datum.rs
+++ b/src/datum.rs
@@ -1,4 +1,4 @@
-use crate::blockchain::Fee;
+use crate::blockchain::{Fee, FeeStrategy};
 use crate::crypto::{self, Keys, Signatures};
 use crate::role::{Accordant, Arbitrating, SwapRole};
 use crate::transaction::TxId;
@@ -46,5 +46,5 @@ where
     RefundAddress(Ar::Address),
     CancelTimelock(Ar::Timelock),
     PunishTimelock(Ar::Timelock),
-    FeeStrategy(Ar::FeeStrategy),
+    FeeStrategy(FeeStrategy<Ar::FeeUnit>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod protocol_message;
 pub mod role;
 //pub mod session;
 pub mod bitcoin;
+pub mod consensus;
 pub mod monero;
 pub mod script;
 pub mod swap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,21 @@
 //! Farcaster Core library
 
+#[macro_use]
+pub mod consensus;
+
+pub mod bitcoin;
 pub mod blockchain;
 pub mod bundle;
 pub mod crypto;
 pub mod datum;
 pub mod instruction;
 pub mod interactions;
+pub mod monero;
 pub mod negotiation;
 pub mod protocol_message;
 pub mod role;
-//pub mod session;
-pub mod bitcoin;
-pub mod consensus;
-pub mod monero;
 pub mod script;
 pub mod swap;
 pub mod transaction;
 pub mod version;
+//pub mod session;

--- a/src/monero/mod.rs
+++ b/src/monero/mod.rs
@@ -1,7 +1,7 @@
 //! Defines and implements all the traits for Monero
 
 use monero::cryptonote::hash::Hash;
-use monero::network::Network;
+//use monero::network::Network;
 use monero::util::key::PrivateKey;
 use monero::util::key::PublicKey;
 
@@ -16,7 +16,7 @@ impl Blockchain for Monero {
     /// Type for the traded asset unit
     type AssetUnit = u64;
 
-    type Network = Network;
+    //type Network = Network;
 
     ///// Type of the blockchain identifier
     //type Id = String;

--- a/src/monero/mod.rs
+++ b/src/monero/mod.rs
@@ -1,7 +1,6 @@
 //! Defines and implements all the traits for Monero
 
 use monero::cryptonote::hash::Hash;
-//use monero::network::Network;
 use monero::util::key::PrivateKey;
 use monero::util::key::PublicKey;
 
@@ -15,24 +14,6 @@ pub struct Monero;
 impl Blockchain for Monero {
     /// Type for the traded asset unit
     type AssetUnit = u64;
-
-    //type Network = Network;
-
-    ///// Type of the blockchain identifier
-    //type Id = String;
-
-    ///// Type of the chain identifier
-    //type ChainId = Network;
-
-    ///// Returns the blockchain identifier
-    //fn id(&self) -> String {
-    //    String::from("xmr")
-    //}
-
-    ///// Returns the chain identifier
-    //fn chain_id(&self) -> Network {
-    //    Network::Mainnet
-    //}
 
     /// Create a new Bitcoin blockchain
     fn new() -> Self {

--- a/src/monero/mod.rs
+++ b/src/monero/mod.rs
@@ -9,7 +9,7 @@ use crate::blockchain::Blockchain;
 use crate::crypto::{Commitment, Curve, Keys};
 use crate::role::Accordant;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct Monero;
 
 impl Blockchain for Monero {

--- a/src/monero/mod.rs
+++ b/src/monero/mod.rs
@@ -38,6 +38,17 @@ impl Blockchain for Monero {
     fn new() -> Self {
         Monero {}
     }
+
+    fn from_u32(bytes: u32) -> Option<Self> {
+        match bytes {
+            0x80000080 => Some(Self::new()),
+            _ => None,
+        }
+    }
+
+    fn to_u32(&self) -> u32 {
+        0x80000080
+    }
 }
 
 pub struct Ed25519;

--- a/src/negotiation.rs
+++ b/src/negotiation.rs
@@ -59,27 +59,27 @@ where
 
     /// Defines the asset and its amount the maker will send to get the assets defined in the
     /// `some` method.
-    pub fn with(&mut self, asset: U, amount: U::AssetUnit) -> &Self {
+    pub fn with(mut self, asset: U, amount: U::AssetUnit) -> Self {
         self.0.accordant = Some(asset);
         self.0.accordant_assets = Some(amount);
         self
     }
 
     /// Sets the timelocks for the proposed offer
-    pub fn with_timelocks(&mut self, cancel: T::Timelock, punish: T::Timelock) -> &Self {
+    pub fn with_timelocks(mut self, cancel: T::Timelock, punish: T::Timelock) -> Self {
         self.0.cancel_timelock = Some(cancel);
         self.0.punish_timelock = Some(punish);
         self
     }
 
     /// Sets the fee strategy for the proposed offer
-    pub fn with_fee(&mut self, strategy: T::FeeStrategy) -> &Self {
+    pub fn with_fee(mut self, strategy: T::FeeStrategy) -> Self {
         self.0.fee_strategy = Some(strategy);
         self
     }
 
     /// Sets the network for the proposed offer
-    pub fn on(&mut self, network: Network) -> &Self {
+    pub fn on(mut self, network: Network) -> Self {
         self.0.network = Some(network);
         self
     }
@@ -89,7 +89,7 @@ where
     ///
     /// This function automatically sets the maker swap role as **Alice** to comply with the buy
     /// contract.
-    pub fn to_offer(&mut self) -> Option<Offer<T, U>> {
+    pub fn to_offer(mut self) -> Option<Offer<T, U>> {
         self.0.maker_role = Some(SwapRole::Alice);
         Some(Offer {
             network: self.0.network?,
@@ -99,7 +99,7 @@ where
             accordant_assets: self.0.accordant_assets?,
             cancel_timelock: self.0.cancel_timelock?,
             punish_timelock: self.0.punish_timelock?,
-            fee_strategy: self.0.fee_strategy.clone()?,
+            fee_strategy: self.0.fee_strategy?,
             maker_role: self.0.maker_role?,
         })
     }
@@ -130,27 +130,27 @@ where
 
     /// Defines the asset and its amount the maker will receive in exchange of the asset and amount
     /// defined in the `some` method.
-    pub fn for_some(&mut self, asset: U, amount: U::AssetUnit) -> &Self {
+    pub fn for_some(mut self, asset: U, amount: U::AssetUnit) -> Self {
         self.0.accordant = Some(asset);
         self.0.accordant_assets = Some(amount);
         self
     }
 
     /// Sets the timelocks for the proposed offer
-    pub fn with_timelocks(&mut self, cancel: T::Timelock, punish: T::Timelock) -> &Self {
+    pub fn with_timelocks(mut self, cancel: T::Timelock, punish: T::Timelock) -> Self {
         self.0.cancel_timelock = Some(cancel);
         self.0.punish_timelock = Some(punish);
         self
     }
 
     /// Sets the fee strategy for the proposed offer
-    pub fn with_fee(&mut self, strategy: T::FeeStrategy) -> &Self {
+    pub fn with_fee(mut self, strategy: T::FeeStrategy) -> Self {
         self.0.fee_strategy = Some(strategy);
         self
     }
 
     /// Sets the network for the proposed offer
-    pub fn on(&mut self, network: Network) -> &Self {
+    pub fn on(mut self, network: Network) -> Self {
         self.0.network = Some(network);
         self
     }
@@ -160,7 +160,7 @@ where
     ///
     /// This function automatically sets the maker swap role as **Bob** to comply with the buy
     /// contract.
-    pub fn to_offer(&mut self) -> Option<Offer<T, U>> {
+    pub fn to_offer(mut self) -> Option<Offer<T, U>> {
         self.0.maker_role = Some(SwapRole::Bob);
         Some(Offer {
             network: self.0.network?,
@@ -170,7 +170,7 @@ where
             accordant_assets: self.0.accordant_assets?,
             cancel_timelock: self.0.cancel_timelock?,
             punish_timelock: self.0.punish_timelock?,
-            fee_strategy: self.0.fee_strategy.clone()?,
+            fee_strategy: self.0.fee_strategy?,
             maker_role: self.0.maker_role?,
         })
     }
@@ -251,26 +251,25 @@ mod tests {
 
     #[test]
     fn maker_buy_arbitrating_assets_offer() {
-        let mut buy = Buy::some(Bitcoin::new(), Amount::from_sat(100000));
-        buy.with(Monero::new(), 200);
-        buy.with_timelocks(10, 10);
-        buy.with_fee(FeeStrategies::fixed_fee(SatPerVByte::from_sat(20)));
-        buy.on(Network::Testnet);
-        assert!(buy.to_offer().is_some());
-        assert_eq!(
-            buy.to_offer().expect("an offer").maker_role,
-            SwapRole::Alice
-        );
+        let offer = Buy::some(Bitcoin::new(), Amount::from_sat(100000))
+            .with(Monero::new(), 200)
+            .with_timelocks(10, 10)
+            .with_fee(FeeStrategies::fixed_fee(SatPerVByte::from_sat(20)))
+            .on(Network::Testnet)
+            .to_offer();
+        assert!(offer.is_some());
+        assert_eq!(offer.expect("an offer").maker_role, SwapRole::Alice);
     }
 
     #[test]
     fn maker_sell_arbitrating_assets_offer() {
-        let mut sell = Sell::some(Bitcoin::new(), Amount::from_sat(100000));
-        sell.for_some(Monero::new(), 200);
-        sell.with_timelocks(10, 10);
-        sell.with_fee(FeeStrategies::fixed_fee(SatPerVByte::from_sat(20)));
-        sell.on(Network::Testnet);
-        assert!(sell.to_offer().is_some());
-        assert_eq!(sell.to_offer().expect("an offer").maker_role, SwapRole::Bob);
+        let offer = Sell::some(Bitcoin::new(), Amount::from_sat(100000))
+            .for_some(Monero::new(), 200)
+            .with_timelocks(10, 10)
+            .with_fee(FeeStrategies::fixed_fee(SatPerVByte::from_sat(20)))
+            .on(Network::Testnet)
+            .to_offer();
+        assert!(offer.is_some());
+        assert_eq!(offer.expect("an offer").maker_role, SwapRole::Bob);
     }
 }

--- a/src/role.rs
+++ b/src/role.rs
@@ -1,5 +1,6 @@
 //! Roles during negotiation and swap phases, blockchain roles, and network definitions.
 
+use std::fmt::Debug;
 use std::io;
 
 use crate::blockchain::{Blockchain, Fee, Onchain};
@@ -75,7 +76,7 @@ pub trait Arbitrating:
     type Address;
 
     //// Defines the type of timelock used for the arbitrating transactions
-    type Timelock: Copy + Encodable + Decodable;
+    type Timelock: Copy + Debug + Encodable + Decodable;
 }
 
 /// An accordant is the blockchain which does not need transaction inside the protocol nor

--- a/src/role.rs
+++ b/src/role.rs
@@ -1,6 +1,9 @@
 //! Roles during negotiation and swap phases, blockchain roles, and network definitions.
 
+use std::io;
+
 use crate::blockchain::{Blockchain, Fee, Onchain};
+use crate::consensus::{self, Decodable, Encodable};
 use crate::crypto::{Commitment, Curve, Keys, Script, Signatures};
 
 /// Defines all possible negociation roles: maker and taker.
@@ -24,6 +27,25 @@ pub trait Role {}
 pub enum SwapRole {
     Alice,
     Bob,
+}
+
+impl Encodable for SwapRole {
+    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+        match self {
+            SwapRole::Alice => 0x01u8.consensus_encode(writer),
+            SwapRole::Bob => 0x02u8.consensus_encode(writer),
+        }
+    }
+}
+
+impl Decodable for SwapRole {
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        match Decodable::consensus_decode(d)? {
+            0x01u8 => Ok(SwapRole::Alice),
+            0x02u8 => Ok(SwapRole::Bob),
+            _ => Err(consensus::Error::UnknownType),
+        }
+    }
 }
 
 /// Alice, the swap role, is the role starting with accordant blockchain assets and exchange them
@@ -53,7 +75,7 @@ pub trait Arbitrating:
     type Address;
 
     //// Defines the type of timelock used for the arbitrating transactions
-    type Timelock: Copy;
+    type Timelock: Copy + Encodable + Decodable;
 }
 
 /// An accordant is the blockchain which does not need transaction inside the protocol nor

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Debug;
 
-use crate::blockchain::FeePolitic;
+use crate::blockchain::{FeePolitic, Network};
 use crate::role::Arbitrating;
 use crate::script;
 
@@ -155,7 +155,7 @@ where
     fn initialize(privkey: Ar::PublicKey) -> Result<Self, Self::Error>;
 
     /// Return the address to use for the funding.
-    fn get_address(&self, network: Ar::Network) -> Result<Ar::Address, Self::Error>;
+    fn get_address(&self, network: Network) -> Result<Ar::Address, Self::Error>;
 
     /// Update the transaction, this is used to update the data when the funding transaction is
     /// seen on-chain.

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Debug;
 
-use crate::blockchain::{FeePolitic, Network};
+use crate::blockchain::{FeePolitic, FeeStrategy, Network};
 use crate::role::Arbitrating;
 use crate::script;
 
@@ -185,7 +185,7 @@ where
     fn initialize(
         prev: &impl Fundable<Ar, Output = Self::Input, Error = Self::Error>,
         lock: script::DataLock<Ar>,
-        fee_strategy: &Ar::FeeStrategy,
+        fee_strategy: &FeeStrategy<Ar::FeeUnit>,
         fee_politic: FeePolitic,
     ) -> Result<Self, Self::Error>;
 }
@@ -212,7 +212,7 @@ where
     fn initialize(
         prev: &impl Lockable<Ar, Output = Self::Input, Error = Self::Error>,
         destination_target: Ar::Address,
-        fee_strategy: &Ar::FeeStrategy,
+        fee_strategy: &FeeStrategy<Ar::FeeUnit>,
         fee_politic: FeePolitic,
     ) -> Result<Self, Self::Error>;
 }
@@ -239,7 +239,7 @@ where
     fn initialize(
         prev: &impl Lockable<Ar, Output = Self::Input, Error = Self::Error>,
         lock: script::DataPunishableLock<Ar>,
-        fee_strategy: &Ar::FeeStrategy,
+        fee_strategy: &FeeStrategy<Ar::FeeUnit>,
         fee_politic: FeePolitic,
     ) -> Result<Self, Self::Error>;
 }
@@ -265,7 +265,7 @@ where
     fn initialize(
         prev: &impl Cancelable<Ar, Output = Self::Input, Error = Self::Error>,
         refund_target: Ar::Address,
-        fee_strategy: &Ar::FeeStrategy,
+        fee_strategy: &FeeStrategy<Ar::FeeUnit>,
         fee_politic: FeePolitic,
     ) -> Result<Self, Self::Error>;
 }
@@ -293,7 +293,7 @@ where
     fn initialize(
         prev: &impl Cancelable<Ar, Output = Self::Input, Error = Self::Error>,
         destination_target: Ar::Address,
-        fee_strategy: &Ar::FeeStrategy,
+        fee_strategy: &FeeStrategy<Ar::FeeUnit>,
         fee_politic: FeePolitic,
     ) -> Result<Self, Self::Error>;
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-cd ..
 cargo test -- --show-output --ignored --test-threads=1

--- a/tests/transactions.rs
+++ b/tests/transactions.rs
@@ -46,12 +46,12 @@ fn create_funding_generic() {
     funding.update(funding_tx_seen).unwrap();
 
     let datalock = script::DataLock {
-        timelock: 10,
+        timelock: CSVTimelock::new(10),
         success: DoubleKeys::new(pubkey, pubkey),
         failure: DoubleKeys::new(pubkey, pubkey),
     };
 
-    let fee = FeeStrategies::fixed_fee(SatPerVByte::from_sat(50));
+    let fee = FeeStrategy::Fixed(SatPerVByte::from_sat(50));
     let politic = FeePolitic::Aggressive;
 
     println!("{:#?}", funding);
@@ -59,7 +59,7 @@ fn create_funding_generic() {
     //println!("{:#?}", lock);
 
     let datapunishablelock = script::DataPunishableLock {
-        timelock: 10,
+        timelock: CSVTimelock::new(10),
         success: DoubleKeys::new(pubkey, pubkey),
         failure: pubkey,
     };

--- a/tests/transactions.rs
+++ b/tests/transactions.rs
@@ -5,7 +5,6 @@ use farcaster_core::script::{self, *};
 use farcaster_core::transaction::*;
 
 use bitcoin::consensus::encode::serialize_hex;
-use bitcoin::network::constants::Network;
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::util::key::{PrivateKey, PublicKey};
 
@@ -33,7 +32,7 @@ fn create_funding_generic() {
     let pubkey = PublicKey::from_private_key(&secp, &privkey);
 
     let mut funding = Funding::initialize(pubkey).unwrap();
-    let address = funding.get_address(Network::Regtest).unwrap();
+    let address = funding.get_address(Network::Local).unwrap();
 
     //println!("Address: {:#?}", client.get_address_info(&address).unwrap());
     //println!("Send funds to: {}", address);


### PR DESCRIPTION
Add public offer serialization based on introducting Farcaster strict encoding and Blockchain related strict encoding. Farcaster encoding wraps values from specific blockchain consensus encoding, as proposed in https://github.com/h4sh3d/RFCs/blob/rfc-10/10-public-offer.md.