### PR TITLE
Strict encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,10 @@ rand_core = { version = "^0.5.0", features = ["getrandom"] }
 thiserror = "1.0.24"
 
 # monero = "0.10.0"
-monero = { git = "https://github.com/monero-rs/monero-rs", branch = "master"}
+monero = { git = "https://github.com/zkao/monero-rs", branch = "strict_encoding"}
 
 # node
-# lnpbp = { git = "https://github.com/zkao/rust-lnpbp.git", branch = "farcaster_encoding" }
-strict_encoding = { path = "../alt/rust-lnpbp/strict_encoding" }
+strict_encoding = "1.2.1"
 
 [dev-dependencies]
 bitcoincore-rpc = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 [dependencies]
 bitcoin = "0.26.0"
 hex = "0.4.3"
-monero = "0.10.0"
 secp256k1 = { version = "0.20.1", features = ["rand-std"] }
 curve25519-dalek = "3.0.0"
 rand_core = { version = "^0.5.0", features = ["getrandom"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ rand_core = { version = "^0.5.0", features = ["getrandom"] }
 thiserror = "1.0.24"
 
 # monero = "0.10.0"
-monero = { path = "../alt/monero-rs" }
+monero = { git = "https://github.com/monero-rs/monero-rs", branch = "master"}
+
 # node
-# lnpbp = { path = "../alt/rust-lnpbp" }
-strict_encoding = { path = "../alt/rust-lnpbp/strict_encoding" }
 # lnpbp = { git = "https://github.com/zkao/rust-lnpbp.git", branch = "farcaster_encoding" }
+strict_encoding = { path = "../alt/rust-lnpbp/strict_encoding" }
 
 [dev-dependencies]
 bitcoincore-rpc = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "farcaster-core"
+name = "farcaster_core"
 version = "0.1.0"
 authors = ["h4sh3d <h4sh3d@protonmail.com>"]
 edition = "2018"
@@ -7,16 +7,16 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoin = "0.26.0"
-hex = "0.4.3"
-secp256k1 = { version = "0.20.1", features = ["rand-std"] }
 curve25519-dalek = "3.0.0"
+hex = "0.4.3"
 rand_core = { version = "^0.5.0", features = ["getrandom"] }
-thiserror = "1.0.24"
-monero = { version = "0.11.0", features = ["strict_encoding_support"] }
-
-# node
+secp256k1 = { version = "0.20.1", features = ["rand-std"] }
 strict_encoding = "1.2.1"
+thiserror = "1.0.24"
+
+# blockchain specific
+bitcoin = "0.26.0"
+monero = { version = "0.11.0", features = ["strict_encoding_support"] }
 
 [dev-dependencies]
 bitcoincore-rpc = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,12 @@ curve25519-dalek = "3.0.0"
 rand_core = { version = "^0.5.0", features = ["getrandom"] }
 thiserror = "1.0.24"
 
+# monero = "0.10.0"
+monero = { path = "../alt/monero-rs" }
+# node
+# lnpbp = { path = "../alt/rust-lnpbp" }
+strict_encoding = { path = "../alt/rust-lnpbp/strict_encoding" }
+# lnpbp = { git = "https://github.com/zkao/rust-lnpbp.git", branch = "farcaster_encoding" }
+
 [dev-dependencies]
 bitcoincore-rpc = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,7 @@ secp256k1 = { version = "0.20.1", features = ["rand-std"] }
 curve25519-dalek = "3.0.0"
 rand_core = { version = "^0.5.0", features = ["getrandom"] }
 thiserror = "1.0.24"
-
-# monero = "0.10.0"
-monero = { git = "https://github.com/zkao/monero-rs", branch = "strict_encoding"}
+monero = { version = "0.11.0", features = ["strict_encoding_support"] }
 
 # node
 strict_encoding = "1.2.1"

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -9,6 +9,7 @@ use bitcoin::util::key::{PrivateKey, PublicKey};
 use bitcoin::util::psbt::PartiallySignedTransaction;
 use std::io;
 
+use std::fmt::{self, Debug, Display, Formatter};
 use crate::blockchain::{
     Blockchain, Fee, FeePolitic, FeeStrategy, FeeStrategyError, FeeUnit, Onchain,
 };
@@ -21,6 +22,13 @@ pub mod transaction;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Bitcoin;
+
+impl Display for Bitcoin {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        println!("btc");
+        Ok(())
+    }
+}
 
 impl Blockchain for Bitcoin {
     /// Type for the traded asset unit

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -19,19 +19,12 @@ use crate::monero::{Ed25519, Monero};
 use monero::cryptonote::hash::Hash;
 
 use crate::role::Arbitrating;
-use std::fmt::{self, Debug, Display, Formatter};
+use std::fmt::Debug;
 
 pub mod transaction;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Bitcoin;
-
-impl Display for Bitcoin {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        println!("btc");
-        Ok(())
-    }
-}
 
 impl Blockchain for Bitcoin {
     /// Type for the traded asset unit

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -16,6 +16,8 @@ use crate::blockchain::{
 use crate::consensus::{self, Decodable, Encodable};
 use crate::crypto::{Commitment, CrossGroupDLEQ, Curve, ECDSAScripts, Keys, Script, Signatures, Proof};
 use crate::monero::{Ed25519, Monero};
+use monero::cryptonote::hash::Hash;
+
 use crate::role::Arbitrating;
 use std::fmt::{self, Debug, Display, Formatter};
 
@@ -208,9 +210,6 @@ pub struct Secp256k1;
 impl Curve for Bitcoin {
     /// Eliptic curve
     type Curve = Secp256k1;
-    fn curve(&self) -> Self::Curve {
-        todo!()
-    }
 }
 
 #[derive(Clone, Debug, StrictDecode, StrictEncode)]
@@ -228,15 +227,9 @@ use strict_encoding::{StrictDecode, StrictEncode};
 #[derive(Clone, Debug)]
 pub struct PDLEQ;
 
-impl PDLEQ {
-    fn to_bytes(&self) -> Vec<u8> {
-        "PDLEQ".to_string().into_bytes()
-    }
-}
-
 impl StrictEncode for PDLEQ {
     fn strict_encode<E: std::io::Write>(&self, mut e: E) -> Result<usize, strict_encoding::Error> {
-        let res = self.to_bytes();
+        let res = Hash::hash(&"Farcaster PDLEQ".as_bytes()).to_bytes();
         e.write(&res)?;
         Ok(res.len())
     }
@@ -244,13 +237,14 @@ impl StrictEncode for PDLEQ {
 
 impl StrictDecode for PDLEQ {
     fn strict_decode<D: std::io::Read>(mut d: D) -> Result<Self, strict_encoding::Error> {
-        let mut buf = [0u8; 8];
+        let mut buf = [0u8; 32];
         d.read_exact(&mut buf)?;
-        if "PDLEQ".to_string().into_bytes() == buf {
+        let expected = Hash::hash(&"Farcaster PDLEQ".as_bytes()).to_bytes();
+        if expected == buf {
             Ok(PDLEQ)
         } else {
             Err(strict_encoding::Error::DataIntegrityError(
-                "string recovered mismatch PDLEQ string".to_string(),
+                "Not PDLEQ type".to_string(),
             ))
         }
     }
@@ -283,42 +277,9 @@ impl Signatures for Bitcoin {
 
 pub struct RingSignatureProof;
 
-impl Ed25519 {
-    fn to_bytes(&self) -> Vec<u8> {
-        "Ed25519".to_string().into_bytes()
-    }
-}
-
-impl Secp256k1 {
-    fn to_bytes(&self) -> Vec<u8> {
-        "Secp256k1".to_string().into_bytes()
-    }
-}
-
-impl StrictEncode for Ed25519 {
-    fn strict_encode<E: std::io::Write>(&self, mut e: E) -> Result<usize, strict_encoding::Error> {
-        let res = self.to_bytes();
-        e.write(&res)?;
-        Ok(res.len())
-    }
-}
-
-impl StrictDecode for Ed25519 {
-    fn strict_decode<D: std::io::Read>(mut d: D) -> Result<Self, strict_encoding::Error> {
-        let mut buf = [0u8; 8];
-        d.read_exact(&mut buf)?;
-        if "Ed25519".to_string().into_bytes() == buf {
-            Ok(Ed25519)
-        } else {
-            Err(strict_encoding::Error::DataIntegrityError(
-                "string recovered mismatch Ed25519 string".to_string(),
-            ))
-        }
-    }
-}
 impl StrictEncode for Secp256k1 {
     fn strict_encode<E: std::io::Write>(&self, mut e: E) -> Result<usize, strict_encoding::Error> {
-        let res = self.to_bytes();
+        let res = Hash::hash(&"Farcaster Secp256k1".as_bytes()).to_bytes();
         e.write(&res)?;
         Ok(res.len())
     }
@@ -326,13 +287,14 @@ impl StrictEncode for Secp256k1 {
 
 impl StrictDecode for Secp256k1 {
     fn strict_decode<D: std::io::Read>(mut d: D) -> Result<Self, strict_encoding::Error> {
-        let mut buf = [0u8; 8];
+        let mut buf = [0u8; 32];
         d.read_exact(&mut buf)?;
-        if "Secp256k1".to_string().into_bytes() == buf {
-            Ok(Secp256k1)
+        let expected = Hash::hash(&"Farcaster Secp256k1".as_bytes()).to_bytes();
+        if expected == buf {
+            Ok(Self)
         } else {
             Err(strict_encoding::Error::DataIntegrityError(
-                "string recovered mismatch PDLEQ string".to_string(),
+                "Not Secp256k1 type".to_string(),
             ))
         }
     }

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -13,7 +13,9 @@ use crate::blockchain::{
     Blockchain, Fee, FeePolitic, FeeStrategy, FeeStrategyError, FeeUnit, Onchain,
 };
 use crate::consensus::{self, Decodable, Encodable};
-use crate::crypto::{Commitment, CrossGroupDLEQ, Curve, ECDSAScripts, Keys, Script, Signatures, Proof};
+use crate::crypto::{
+    Commitment, CrossGroupDLEQ, Curve, ECDSAScripts, Keys, Proof, Script, Signatures,
+};
 use crate::monero::{Ed25519, Monero};
 use monero::cryptonote::hash::Hash;
 

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -2,7 +2,6 @@
 
 use bitcoin::blockdata::transaction::TxOut;
 use bitcoin::hash_types::PubkeyHash;
-use bitcoin::network::constants::Network;
 use bitcoin::secp256k1::Signature;
 use bitcoin::util::address::Address;
 use bitcoin::util::amount::Amount;

--- a/src/bitcoin/transaction/mod.rs
+++ b/src/bitcoin/transaction/mod.rs
@@ -6,18 +6,18 @@ use bitcoin::blockdata::script::{Builder, Script};
 use bitcoin::blockdata::transaction::{OutPoint, SigHashType, TxIn, TxOut};
 use bitcoin::hashes::sha256d::Hash;
 use bitcoin::network::constants::Network as BtcNetwork;
-use bitcoin::secp256k1::{Message, Secp256k1, SerializedSignature, Signing};
+use bitcoin::secp256k1::{Message, Secp256k1, Signature, Signing};
 use bitcoin::util::address::{self, Address};
 use bitcoin::util::bip143::SigHashCache;
 use bitcoin::util::key::{PrivateKey, PublicKey};
 use bitcoin::util::psbt::{self, PartiallySignedTransaction};
 
-use crate::bitcoin::{Bitcoin, SatPerVByte, PDLEQ};
+use crate::bitcoin::{Bitcoin, SatPerVByte, PDLEQ, FeeStrategies, ECDSAAdaptorSig};
 use crate::blockchain::{Fee, FeePolitic, FeeStrategy, FeeStrategyError, Network};
 use crate::script;
 use crate::transaction::{
     AdaptorSignable, Broadcastable, Buyable, Cancelable, Failable, Forkable, Fundable, Linkable,
-    Lockable, Punishable, Refundable, Signable, Transaction,
+    Lockable, Punishable, Refundable, Signable, Transaction
 };
 
 #[derive(Debug)]
@@ -290,7 +290,7 @@ impl<'a> AsRef<TxIn> for TxInRef<'a> {
 }
 
 impl Signable<Bitcoin> for Tx<Lock> {
-    fn generate_witness(&mut self, privkey: &PrivateKey) -> Result<SerializedSignature, Error> {
+    fn generate_witness(&mut self, privkey: &PrivateKey) -> Result<Signature, Error> {
         {
             // TODO validate the transaction before signing
         }
@@ -315,10 +315,11 @@ impl Signable<Bitcoin> for Tx<Lock> {
         println!("{:?}", script);
         println!("{:?}", value);
         println!("{:?}", sighash_type);
+
         let sig = sign_input(&mut secp, txin, &script, value, sighash_type, &privkey.key)?;
 
         // Finalize the witness
-        let mut full_sig = sig.clone().to_vec();
+        let mut full_sig = sig.serialize_der().to_vec();
         full_sig.extend_from_slice(&[sighash_type.as_u32() as u8]);
 
         let pubkey = PublicKey::from_private_key(&secp, &privkey);
@@ -330,7 +331,7 @@ impl Signable<Bitcoin> for Tx<Lock> {
     fn verify_witness(
         &mut self,
         _pubkey: &PublicKey,
-        _sig: SerializedSignature,
+        _sig: Signature,
     ) -> Result<(), Error> {
         todo!()
     }
@@ -356,7 +357,7 @@ impl Buyable<Bitcoin> for Tx<Buy> {
 }
 
 impl Signable<Bitcoin> for Tx<Buy> {
-    fn generate_witness(&mut self, _privkey: &PrivateKey) -> Result<SerializedSignature, Error> {
+    fn generate_witness(&mut self, _privkey: &PrivateKey) -> Result<Signature, Error> {
         {
             // TODO validate the transaction before signing
         }
@@ -366,7 +367,7 @@ impl Signable<Bitcoin> for Tx<Buy> {
     fn verify_witness(
         &mut self,
         _pubkey: &PublicKey,
-        _sig: SerializedSignature,
+        _sig: Signature,
     ) -> Result<(), Error> {
         todo!()
     }
@@ -377,7 +378,7 @@ impl AdaptorSignable<Bitcoin> for Tx<Buy> {
         &mut self,
         _privkey: &PrivateKey,
         _adaptor: &PublicKey,
-    ) -> Result<(SerializedSignature, PublicKey, PDLEQ), Error> {
+    ) -> Result<ECDSAAdaptorSig, Error> {
         todo!()
     }
 
@@ -385,7 +386,7 @@ impl AdaptorSignable<Bitcoin> for Tx<Buy> {
         &mut self,
         _pubkey: &PublicKey,
         _adaptor: &PublicKey,
-        _sig: (SerializedSignature, PublicKey, PDLEQ),
+        _sig: ECDSAAdaptorSig,
     ) -> Result<(), Error> {
         todo!()
     }
@@ -462,14 +463,14 @@ impl Forkable<Bitcoin> for Tx<Cancel> {
     fn generate_failure_witness(
         &mut self,
         _privkey: &PrivateKey,
-    ) -> Result<SerializedSignature, Error> {
+    ) -> Result<Signature, Error> {
         todo!()
     }
 
     fn verify_failure_witness(
         &mut self,
         _pubkey: &PublicKey,
-        _sig: SerializedSignature,
+        _sig: Signature,
     ) -> Result<(), Error> {
         todo!()
     }
@@ -524,14 +525,14 @@ impl Refundable<Bitcoin> for Tx<Refund> {
 }
 
 impl Signable<Bitcoin> for Tx<Refund> {
-    fn generate_witness(&mut self, _privkey: &PrivateKey) -> Result<SerializedSignature, Error> {
+    fn generate_witness(&mut self, _privkey: &PrivateKey) -> Result<Signature, Error> {
         todo!()
     }
 
     fn verify_witness(
         &mut self,
         _pubkey: &PublicKey,
-        _sig: SerializedSignature,
+        _sig: Signature,
     ) -> Result<(), Error> {
         todo!()
     }
@@ -542,7 +543,7 @@ impl AdaptorSignable<Bitcoin> for Tx<Refund> {
         &mut self,
         _privkey: &PrivateKey,
         _adaptor: &PublicKey,
-    ) -> Result<(SerializedSignature, PublicKey, PDLEQ), Error> {
+    ) -> Result<ECDSAAdaptorSig, Error> {
         todo!()
     }
 
@@ -550,7 +551,7 @@ impl AdaptorSignable<Bitcoin> for Tx<Refund> {
         &mut self,
         _pubkey: &PublicKey,
         _adaptor: &PublicKey,
-        _sig: (SerializedSignature, PublicKey, PDLEQ),
+        _sig: ECDSAAdaptorSig,
     ) -> Result<(), Error> {
         todo!()
     }
@@ -579,14 +580,14 @@ impl Forkable<Bitcoin> for Tx<Punish> {
     fn generate_failure_witness(
         &mut self,
         _privkey: &PrivateKey,
-    ) -> Result<SerializedSignature, Error> {
+    ) -> Result<Signature, Error> {
         todo!()
     }
 
     fn verify_failure_witness(
         &mut self,
         _pubkey: &PublicKey,
-        _sig: SerializedSignature,
+        _sig: Signature,
     ) -> Result<(), Error> {
         todo!()
     }
@@ -620,7 +621,7 @@ pub fn sign_input<'a, C>(
     value: u64,
     sighash_type: SigHashType,
     secret_key: &bitcoin::secp256k1::SecretKey,
-) -> Result<SerializedSignature, bitcoin::secp256k1::Error>
+) -> Result<Signature, bitcoin::secp256k1::Error>
 where
     C: Signing,
 {
@@ -630,7 +631,7 @@ where
     let msg = Message::from_slice(&sighash[..])?;
     let mut sig = context.sign(&msg, secret_key);
     sig.normalize_s();
-    Ok(sig.serialize_der())
+    Ok(sig)
 }
 
 #[cfg(test)]

--- a/src/bitcoin/transaction/mod.rs
+++ b/src/bitcoin/transaction/mod.rs
@@ -12,7 +12,7 @@ use bitcoin::util::bip143::SigHashCache;
 use bitcoin::util::key::{PrivateKey, PublicKey};
 use bitcoin::util::psbt::{self, PartiallySignedTransaction};
 
-use crate::bitcoin::{Bitcoin, SatPerVByte, PDLEQ, FeeStrategies, ECDSAAdaptorSig};
+use crate::bitcoin::{Bitcoin, SatPerVByte, ECDSAAdaptorSig};
 use crate::blockchain::{Fee, FeePolitic, FeeStrategy, FeeStrategyError, Network};
 use crate::script;
 use crate::transaction::{

--- a/src/bitcoin/transaction/mod.rs
+++ b/src/bitcoin/transaction/mod.rs
@@ -12,12 +12,12 @@ use bitcoin::util::bip143::SigHashCache;
 use bitcoin::util::key::{PrivateKey, PublicKey};
 use bitcoin::util::psbt::{self, PartiallySignedTransaction};
 
-use crate::bitcoin::{Bitcoin, SatPerVByte, ECDSAAdaptorSig};
+use crate::bitcoin::{Bitcoin, ECDSAAdaptorSig, SatPerVByte};
 use crate::blockchain::{Fee, FeePolitic, FeeStrategy, FeeStrategyError, Network};
 use crate::script;
 use crate::transaction::{
     AdaptorSignable, Broadcastable, Buyable, Cancelable, Failable, Forkable, Fundable, Linkable,
-    Lockable, Punishable, Refundable, Signable, Transaction
+    Lockable, Punishable, Refundable, Signable, Transaction,
 };
 
 #[derive(Debug)]
@@ -328,11 +328,7 @@ impl Signable<Bitcoin> for Tx<Lock> {
         Ok(sig)
     }
 
-    fn verify_witness(
-        &mut self,
-        _pubkey: &PublicKey,
-        _sig: Signature,
-    ) -> Result<(), Error> {
+    fn verify_witness(&mut self, _pubkey: &PublicKey, _sig: Signature) -> Result<(), Error> {
         todo!()
     }
 }
@@ -364,11 +360,7 @@ impl Signable<Bitcoin> for Tx<Buy> {
         todo!()
     }
 
-    fn verify_witness(
-        &mut self,
-        _pubkey: &PublicKey,
-        _sig: Signature,
-    ) -> Result<(), Error> {
+    fn verify_witness(&mut self, _pubkey: &PublicKey, _sig: Signature) -> Result<(), Error> {
         todo!()
     }
 }
@@ -460,10 +452,7 @@ impl Cancelable<Bitcoin> for Tx<Cancel> {
 }
 
 impl Forkable<Bitcoin> for Tx<Cancel> {
-    fn generate_failure_witness(
-        &mut self,
-        _privkey: &PrivateKey,
-    ) -> Result<Signature, Error> {
+    fn generate_failure_witness(&mut self, _privkey: &PrivateKey) -> Result<Signature, Error> {
         todo!()
     }
 
@@ -529,11 +518,7 @@ impl Signable<Bitcoin> for Tx<Refund> {
         todo!()
     }
 
-    fn verify_witness(
-        &mut self,
-        _pubkey: &PublicKey,
-        _sig: Signature,
-    ) -> Result<(), Error> {
+    fn verify_witness(&mut self, _pubkey: &PublicKey, _sig: Signature) -> Result<(), Error> {
         todo!()
     }
 }
@@ -577,10 +562,7 @@ impl Punishable<Bitcoin> for Tx<Punish> {
 }
 
 impl Forkable<Bitcoin> for Tx<Punish> {
-    fn generate_failure_witness(
-        &mut self,
-        _privkey: &PrivateKey,
-    ) -> Result<Signature, Error> {
+    fn generate_failure_witness(&mut self, _privkey: &PrivateKey) -> Result<Signature, Error> {
         todo!()
     }
 

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -45,10 +45,11 @@ impl<T: Blockchain> Decodable for T {
 }
 
 /// Defines the types a blockchain needs to interact onchain, i.e. the transaction types.
+use strict_encoding::{StrictEncode, StrictDecode};
 pub trait Onchain {
     /// Defines the transaction format used to transfer partial transaction between participant for
     /// the arbitrating blockchain
-    type PartialTransaction;
+    type PartialTransaction: StrictEncode + StrictDecode;
 
     /// Defines the finalized transaction format for the arbitrating blockchain
     type Transaction;

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -45,7 +45,7 @@ impl<T: Blockchain> Decodable for T {
 }
 
 /// Defines the types a blockchain needs to interact onchain, i.e. the transaction types.
-use strict_encoding::{StrictEncode, StrictDecode};
+use strict_encoding::{StrictDecode, StrictEncode};
 pub trait Onchain {
     /// Defines the transaction format used to transfer partial transaction between participant for
     /// the arbitrating blockchain

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,6 +1,7 @@
 //! Cryptographic type definitions and primitives supported in Farcaster
 
 use crate::role::{Accordant, Arbitrating};
+use strict_encoding::{StrictDecode, StrictEncode};
 
 pub enum Key<Ar, Ac>
 where
@@ -50,12 +51,12 @@ pub trait Keys {
     type PrivateKey;
 
     /// Public key type given the blockchain and the crypto engine
-    type PublicKey;
+    type PublicKey: StrictEncode + StrictDecode;
 }
 
 pub trait Commitment {
     /// Commitment type given the blockchain and the crypto engine
-    type Commitment;
+    type Commitment: StrictDecode + StrictEncode;
 }
 
 pub trait Signatures {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -91,7 +91,6 @@ where
 /// Eliptic curve ed25519 or secp256k1
 pub trait Curve {
     type Curve: StrictEncode + StrictDecode + Clone + std::fmt::Debug;
-    fn curve(&self) -> Self::Curve;
 }
 /// Defines the means of arbitration, such as ECDSAScripts, TrSchnorrScripts and TrMuSig2
 pub trait Script {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -33,12 +33,14 @@ where
     Regular(Ar::Signature),
 }
 
-pub enum Proof<Ar, Ac>
+#[derive(Clone, Debug, StrictDecode, StrictEncode)]
+#[strict_encoding_crate(strict_encoding)]
+pub struct Proof<Ar, Ac>
 where
-    Ar: Arbitrating,
-    Ac: Accordant,
+    Ar: Curve,
+    Ac: Curve,
 {
-    CrossGroupDLEQ(Box<dyn CrossGroupDLEQ<Ar, Ac>>),
+    pair: (Ar::Curve, Ac::Curve),
 }
 
 /// This trait is defined for blockchains once per cryptographic engine wanted and allow a
@@ -54,18 +56,22 @@ pub trait Keys {
     type PublicKey: StrictEncode + StrictDecode;
 }
 
+pub trait PrivateViewKey {
+    type PrivateViewKey: StrictEncode + StrictDecode;
+}
+
 pub trait Commitment {
     /// Commitment type given the blockchain and the crypto engine
-    type Commitment: StrictDecode + StrictEncode;
+    type Commitment: StrictEncode + StrictDecode;
 }
 
 pub trait Signatures {
     /// Defines the signature format for the arbitrating blockchain
-    type Signature;
+    type Signature: StrictEncode + StrictDecode;
 
     /// Defines the adaptor signature format for the arbitrating blockchain. Adaptor signature may
     /// have a different format from the signature depending on the cryptographic engine used.
-    type AdaptorSignature;
+    type AdaptorSignature: StrictEncode + StrictDecode;
 }
 
 /// Defines a type of cryptography used inside arbitrating transactions to validate the
@@ -84,9 +90,9 @@ where
 
 /// Eliptic curve ed25519 or secp256k1
 pub trait Curve {
-    type Curve;
+    type Curve: StrictEncode + StrictDecode + Clone + std::fmt::Debug;
+    fn curve(&self) -> Self::Curve;
 }
-
 /// Defines the means of arbitration, such as ECDSAScripts, TrSchnorrScripts and TrMuSig2
 pub trait Script {
     type Script;

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,6 +1,5 @@
 //! Cryptographic type definitions and primitives supported in Farcaster
 
-use crate::role::{Accordant, Arbitrating};
 use strict_encoding::{StrictDecode, StrictEncode};
 
 pub enum Key<Ar, Ac>

--- a/src/datum.rs
+++ b/src/datum.rs
@@ -1,6 +1,6 @@
 use crate::blockchain::{Fee, FeeStrategy};
-use crate::crypto::{self, Keys, Signatures, Curve};
-use crate::role::{Accordant, Arbitrating, SwapRole};
+use crate::crypto::{self, Keys, Signatures};
+use crate::role::{Arbitrating, SwapRole};
 use crate::transaction::TxId;
 
 pub trait Datum {}

--- a/src/datum.rs
+++ b/src/datum.rs
@@ -1,5 +1,5 @@
 use crate::blockchain::{Fee, FeeStrategy};
-use crate::crypto::{self, Keys, Signatures};
+use crate::crypto::{self, Keys, Signatures, Curve};
 use crate::role::{Accordant, Arbitrating, SwapRole};
 use crate::transaction::TxId;
 
@@ -30,13 +30,17 @@ where
     pub value: crypto::Signature<Ar>,
 }
 
-pub struct Proof<Ar, Ac>
-where
-    Ar: Arbitrating,
-    Ac: Accordant,
-{
-    pub proof: crypto::Proof<Ar, Ac>,
-}
+pub use crate::crypto::Proof;
+// use strict_encoding::{StrictEncode, StrictDecode};
+// #[derive(Clone, Debug, StrictDecode, StrictEncode)]
+// #[strict_encoding_crate(strict_encoding)]
+// pub struct Proof<Ar, Ac>
+// where
+//     Ar: Curve + Clone,
+//     Ac: Curve + Clone,
+// {
+//     pub proof: crypto::InnerProof<Ar, Ac>,
+// }
 
 pub enum Parameter<Ar>
 where

--- a/src/monero/mod.rs
+++ b/src/monero/mod.rs
@@ -3,18 +3,20 @@
 use std::fmt::{self, Debug, Display, Formatter};
 use bitcoin::hash_types::PubkeyHash;  // DELETEME encoding test
 use monero::cryptonote::hash::Hash;
+use crate::blockchain::Blockchain;
+use crate::crypto::{Commitment, Curve, Keys, PrivateViewKey};
+use crate::role::Accordant;
+use bitcoin::hash_types::PubkeyHash; // DELETEME encoding test
+use monero::network::Network;
 use monero::util::key::PrivateKey;
 use monero::util::key::PublicKey;
-
-use crate::blockchain::Blockchain;
-use crate::crypto::{Commitment, Curve, Keys};
-use crate::role::Accordant;
+use std::fmt::{self, Debug, Display, Formatter};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Monero;
 
 impl Display for Monero {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, _f: &mut Formatter<'_>) -> fmt::Result {
         println!("xmr");
         Ok(())
     }
@@ -41,10 +43,14 @@ impl Blockchain for Monero {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct Ed25519;
 
 impl Curve for Monero {
     type Curve = Ed25519;
+    fn curve(&self) -> Self::Curve {
+        todo!()
+    }
 }
 
 impl Accordant for Monero {}
@@ -55,6 +61,10 @@ impl Keys for Monero {
 
     /// Public key type for the blockchain
     type PublicKey = PublicKey;
+}
+
+impl PrivateViewKey for Monero {
+    type PrivateViewKey = PrivateKey;
 }
 
 impl Commitment for Monero {

--- a/src/monero/mod.rs
+++ b/src/monero/mod.rs
@@ -1,16 +1,13 @@
 //! Defines and implements all the traits for Monero
 
 use std::fmt::{self, Debug, Display, Formatter};
-use bitcoin::hash_types::PubkeyHash;  // DELETEME encoding test
 use monero::cryptonote::hash::Hash;
 use crate::blockchain::Blockchain;
 use crate::crypto::{Commitment, Curve, Keys, PrivateViewKey};
 use crate::role::Accordant;
 use bitcoin::hash_types::PubkeyHash; // DELETEME encoding test
-use monero::network::Network;
 use monero::util::key::PrivateKey;
 use monero::util::key::PublicKey;
-use std::fmt::{self, Debug, Display, Formatter};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Monero;
@@ -69,7 +66,6 @@ impl Commitment for Monero {
 }
 
 use strict_encoding::{StrictEncode, StrictDecode};
-use monero::cryptonote::hash::Hash;
 impl StrictEncode for Ed25519 {
     fn strict_encode<E: std::io::Write>(&self, mut e: E) -> Result<usize, strict_encoding::Error> {
         let res = Hash::hash(&"Farcaster Ed25519".as_bytes()).to_bytes();

--- a/src/monero/mod.rs
+++ b/src/monero/mod.rs
@@ -1,13 +1,13 @@
 //! Defines and implements all the traits for Monero
 
-use std::fmt::{self, Debug, Display, Formatter};
-use monero::cryptonote::hash::Hash;
 use crate::blockchain::Blockchain;
 use crate::crypto::{Commitment, Curve, Keys, PrivateViewKey};
 use crate::role::Accordant;
 use bitcoin::hash_types::PubkeyHash; // DELETEME encoding test
+use monero::cryptonote::hash::Hash;
 use monero::util::key::PrivateKey;
 use monero::util::key::PublicKey;
+use std::fmt::{self, Debug, Display, Formatter};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Monero;
@@ -65,7 +65,7 @@ impl Commitment for Monero {
     type Commitment = PubkeyHash;
 }
 
-use strict_encoding::{StrictEncode, StrictDecode};
+use strict_encoding::{StrictDecode, StrictEncode};
 impl StrictEncode for Ed25519 {
     fn strict_encode<E: std::io::Write>(&self, mut e: E) -> Result<usize, strict_encoding::Error> {
         let res = Hash::hash(&"Farcaster Ed25519".as_bytes()).to_bytes();

--- a/src/monero/mod.rs
+++ b/src/monero/mod.rs
@@ -1,5 +1,7 @@
 //! Defines and implements all the traits for Monero
 
+use std::fmt::{self, Debug, Display, Formatter};
+use bitcoin::hash_types::PubkeyHash;  // DELETEME encoding test
 use monero::cryptonote::hash::Hash;
 use monero::util::key::PrivateKey;
 use monero::util::key::PublicKey;
@@ -10,6 +12,13 @@ use crate::role::Accordant;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Monero;
+
+impl Display for Monero {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        println!("xmr");
+        Ok(())
+    }
+}
 
 impl Blockchain for Monero {
     /// Type for the traded asset unit
@@ -49,5 +58,5 @@ impl Keys for Monero {
 }
 
 impl Commitment for Monero {
-    type Commitment = Hash;
+    type Commitment = PubkeyHash;
 }

--- a/src/monero/mod.rs
+++ b/src/monero/mod.rs
@@ -48,9 +48,6 @@ pub struct Ed25519;
 
 impl Curve for Monero {
     type Curve = Ed25519;
-    fn curve(&self) -> Self::Curve {
-        todo!()
-    }
 }
 
 impl Accordant for Monero {}
@@ -69,4 +66,29 @@ impl PrivateViewKey for Monero {
 
 impl Commitment for Monero {
     type Commitment = PubkeyHash;
+}
+
+use strict_encoding::{StrictEncode, StrictDecode};
+use monero::cryptonote::hash::Hash;
+impl StrictEncode for Ed25519 {
+    fn strict_encode<E: std::io::Write>(&self, mut e: E) -> Result<usize, strict_encoding::Error> {
+        let res = Hash::hash(&"Farcaster Ed25519".as_bytes()).to_bytes();
+        e.write(&res)?;
+        Ok(res.len())
+    }
+}
+
+impl StrictDecode for Ed25519 {
+    fn strict_decode<D: std::io::Read>(mut d: D) -> Result<Self, strict_encoding::Error> {
+        let mut buf = [0u8; 32];
+        d.read_exact(&mut buf)?;
+        let expected = Hash::hash(&"Farcaster Ed25519".as_bytes()).to_bytes();
+        if expected == buf {
+            Ok(Self)
+        } else {
+            Err(strict_encoding::Error::DataIntegrityError(
+                "Not Ed25519 type".to_string(),
+            ))
+        }
+    }
 }

--- a/src/protocol_message.rs
+++ b/src/protocol_message.rs
@@ -2,11 +2,10 @@
 
 use crate::crypto::{Commitment, Proof, Signatures, Curve};
 use crate::role::{Accordant, Arbitrating};
+use strict_encoding::{StrictDecode, StrictEncode};
 
 /// Trait for defining inter-daemon communication messages.
-pub trait ProtocolMessage {}
-
-use strict_encoding::{StrictDecode, StrictEncode};
+pub trait ProtocolMessage: StrictEncode + StrictDecode {}
 
 /// `commit_alice_session_params` forces Alice to commit to the result of her cryptographic setup
 /// before receiving Bob's setup. This is done to remove adaptive behavior.
@@ -187,7 +186,7 @@ impl<Ar> ProtocolMessage for RefundProcedureSignatures<Ar> where Ar: Arbitrating
 /// transaction and the transaction itself. Uppon reception Alice must validate the transaction and
 /// the adaptor signature.
 #[derive(Clone, Debug, StrictDecode, StrictEncode)]
-    #[strict_encoding_crate(strict_encoding)]
+#[strict_encoding_crate(strict_encoding)]
 pub struct BuyProcedureSignature<Ar>
 where
     Ar: Arbitrating,
@@ -202,6 +201,9 @@ impl<Ar> ProtocolMessage for BuyProcedureSignature<Ar> where Ar: Arbitrating {}
 
 /// `abort` is an `OPTIONAL` courtesy message from either swap partner to inform the counterparty
 /// that they have aborted the swap with an `OPTIONAL` message body to provide the reason.
+
+#[derive(Clone, Debug, StrictDecode, StrictEncode)]
+#[strict_encoding_crate(strict_encoding)]
 pub struct Abort {
     /// OPTIONAL `body`: error code | string
     pub error_body: Option<String>,

--- a/src/protocol_message.rs
+++ b/src/protocol_message.rs
@@ -8,15 +8,6 @@ pub trait ProtocolMessage {}
 
 use strict_encoding::{StrictDecode, StrictEncode};
 
-pub trait ProtMsg {}
-
-impl<Ar, Ac> ProtMsg for CommitAliceSessionParams<Ar, Ac>
-where
-    Ar: Commitment,
-    Ac: Commitment,
-{
-}
-
 /// `commit_alice_session_params` forces Alice to commit to the result of her cryptographic setup
 /// before receiving Bob's setup. This is done to remove adaptive behavior.
 #[derive(Clone, Debug, StrictDecode, StrictEncode)]

--- a/src/protocol_message.rs
+++ b/src/protocol_message.rs
@@ -135,7 +135,7 @@ where
     /// The `K_s^b` spend public key
     pub view: Ac::PrivateViewKey,
     // /// The cross-group discrete logarithm zero-knowledge proof
-    // pub proof: Proof<Ar, Ac>, // FIXME
+    pub proof: Proof<Ar, Ac>,
 }
 
 impl<Ar, Ac> ProtocolMessage for RevealBobSessionParams<Ar, Ac>
@@ -159,7 +159,7 @@ where
     pub cancel: Ar::PartialTransaction,
     /// The arbitrating `refund (e)` transaction
     pub refund: Ar::PartialTransaction,
-    // /// The `Bc` `cancel (d)` signature
+    /// The `Bc` `cancel (d)` signature
     pub cancel_sig: Ar::Signature, 
 }
 

--- a/src/protocol_message.rs
+++ b/src/protocol_message.rs
@@ -1,17 +1,31 @@
 //! Protocol messages exchanged between swap daemons
 
-use crate::crypto::Proof;
+
+use crate::crypto::{Commitment, Proof, Keys};
 use crate::role::{Accordant, Arbitrating};
 
 /// Trait for defining inter-daemon communication messages.
 pub trait ProtocolMessage {}
 
+use strict_encoding::{StrictDecode, StrictEncode};
+
+pub trait ProtMsg {}
+
+impl<Ar, Ac> ProtMsg for CommitAliceSessionParams<Ar, Ac>
+where
+    Ar: Commitment,
+    Ac: Commitment,
+{
+}
+
 /// `commit_alice_session_params` forces Alice to commit to the result of her cryptographic setup
 /// before receiving Bob's setup. This is done to remove adaptive behavior.
+#[derive(Clone, Debug, StrictDecode, StrictEncode)]
+#[strict_encoding_crate(strict_encoding)]
 pub struct CommitAliceSessionParams<Ar, Ac>
 where
-    Ar: Arbitrating,
-    Ac: Accordant,
+    Ar: Commitment,
+    Ac: Commitment,
 {
     /// Commitment to `Ab` curve point
     pub buy: Ar::Commitment,
@@ -29,10 +43,16 @@ where
     pub view: Ac::Commitment,
 }
 
+impl<Ar: Commitment, Ac: Commitment> std::fmt::Display for CommitAliceSessionParams<Ar, Ac> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
 impl<Ar, Ac> ProtocolMessage for CommitAliceSessionParams<Ar, Ac>
 where
-    Ar: Arbitrating,
-    Ac: Accordant,
+    Ar: Commitment,
+    Ac: Commitment,
 {
 }
 
@@ -40,8 +60,8 @@ where
 /// before receiving Alice's setup. This is done to remove adaptive behavior.
 pub struct CommitBobSessionParams<Ar, Ac>
 where
-    Ar: Arbitrating,
-    Ac: Accordant,
+    Ar: Commitment,
+    Ac: Commitment,
 {
     /// Commitment to `Bb` curve point
     pub buy: Ar::Commitment,
@@ -59,8 +79,8 @@ where
 
 impl<Ar, Ac> ProtocolMessage for CommitBobSessionParams<Ar, Ac>
 where
-    Ar: Arbitrating,
-    Ac: Accordant,
+    Ar: Commitment,
+    Ac: Commitment,
 {
 }
 

--- a/src/protocol_message.rs
+++ b/src/protocol_message.rs
@@ -1,6 +1,6 @@
 //! Protocol messages exchanged between swap daemons
 
-use crate::crypto::{Commitment, Proof, Signatures, Curve};
+use crate::crypto::{Commitment, Curve, Proof, Signatures};
 use crate::role::{Accordant, Arbitrating};
 use strict_encoding::{StrictDecode, StrictEncode};
 
@@ -160,7 +160,7 @@ where
     /// The arbitrating `refund (e)` transaction
     pub refund: Ar::PartialTransaction,
     /// The `Bc` `cancel (d)` signature
-    pub cancel_sig: Ar::Signature, 
+    pub cancel_sig: Ar::Signature,
 }
 
 impl<Ar> ProtocolMessage for CoreArbitratingSetup<Ar> where Ar: Arbitrating {}
@@ -221,7 +221,7 @@ mod tests {
     use bitcoin::util::psbt::PartiallySignedTransaction;
 
     use super::{Abort, BuyProcedureSignature};
-    use crate::bitcoin::{Bitcoin, PDLEQ, ECDSAAdaptorSig};
+    use crate::bitcoin::{Bitcoin, ECDSAAdaptorSig, PDLEQ};
 
     #[test]
     fn create_abort_message() {
@@ -255,7 +255,11 @@ mod tests {
 
         let _ = BuyProcedureSignature::<Bitcoin> {
             buy: (PartiallySignedTransaction::from_unsigned_tx(tx).expect("PSBT should work here")),
-            buy_adaptor_sig: ECDSAAdaptorSig{sig, point, dleq: pdleq},
+            buy_adaptor_sig: ECDSAAdaptorSig {
+                sig,
+                point,
+                dleq: pdleq,
+            },
         };
     }
 }

--- a/src/role.rs
+++ b/src/role.rs
@@ -5,8 +5,8 @@ use std::io;
 
 use crate::blockchain::{Blockchain, Fee, Onchain};
 use crate::consensus::{self, Decodable, Encodable};
-use crate::crypto::{Commitment, Curve, Keys, Script, Signatures, PrivateViewKey};
-use strict_encoding::{StrictEncode, StrictDecode};
+use crate::crypto::{Commitment, Curve, Keys, PrivateViewKey, Script, Signatures};
+use strict_encoding::{StrictDecode, StrictEncode};
 
 /// Defines all possible negociation roles: maker and taker.
 pub enum NegotiationRole {

--- a/src/role.rs
+++ b/src/role.rs
@@ -5,7 +5,8 @@ use std::io;
 
 use crate::blockchain::{Blockchain, Fee, Onchain};
 use crate::consensus::{self, Decodable, Encodable};
-use crate::crypto::{Commitment, Curve, Keys, Script, Signatures};
+use crate::crypto::{Commitment, Curve, Keys, Script, Signatures, PrivateViewKey};
+use strict_encoding::{StrictEncode, StrictDecode};
 
 /// Defines all possible negociation roles: maker and taker.
 pub enum NegotiationRole {
@@ -73,11 +74,10 @@ pub trait Arbitrating:
     Blockchain + Keys + Commitment + Signatures + Curve + Script + Onchain + Fee + Clone
 {
     /// Defines the address format for the arbitrating blockchain
-    type Address;
+    type Address: StrictEncode + StrictDecode;
     /// Defines the type of timelock used for the arbitrating transactions
     type Timelock: Copy + Debug + Encodable + Decodable;
 }
-
 /// An accordant is the blockchain which does not need transaction inside the protocol nor
 /// timelocks, it is the blockchain with the less requirements for an atomic swap.
-pub trait Accordant: Blockchain + Keys + Curve + Commitment + Clone {}
+pub trait Accordant: Blockchain + Keys + Curve + Commitment + Clone + PrivateViewKey {}

--- a/src/role.rs
+++ b/src/role.rs
@@ -70,15 +70,14 @@ pub enum BlockchainRole {
 /// An arbitrating is the blockchain which will act as the decision engine, the arbitrating
 /// blockchain will use transaction to transfer the funds on both blockchains.
 pub trait Arbitrating:
-    Blockchain + Keys + Commitment + Signatures + Curve + Script + Onchain + Fee
+    Blockchain + Keys + Commitment + Signatures + Curve + Script + Onchain + Fee + Clone
 {
     /// Defines the address format for the arbitrating blockchain
     type Address;
-
-    //// Defines the type of timelock used for the arbitrating transactions
+    /// Defines the type of timelock used for the arbitrating transactions
     type Timelock: Copy + Debug + Encodable + Decodable;
 }
 
 /// An accordant is the blockchain which does not need transaction inside the protocol nor
 /// timelocks, it is the blockchain with the less requirements for an atomic swap.
-pub trait Accordant: Blockchain + Keys + Curve + Commitment {}
+pub trait Accordant: Blockchain + Keys + Curve + Commitment + Clone {}


### PR DESCRIPTION
@h4sh3d Please see the usage of strict encoding required by the node

monero strict encoding strategy implemented here: 
https://github.com/zkao/rust-lnpbp/tree/farcaster_encoding