### PR TITLE
Add strict encoding for public offer

### DIFF
--- a/core/src/negotiation.rs
+++ b/core/src/negotiation.rs
@@ -1,6 +1,7 @@
 //! Negotiation phase utilities
 
 //use internet2::session::node_addr::NodeAddr;
+use strict_encoding::{StrictDecode, StrictEncode};
 use thiserror::Error;
 
 use std::io;
@@ -356,6 +357,30 @@ where
         Ok(PublicOffer {
             version: Decodable::consensus_decode(d)?,
             offer: Decodable::consensus_decode(d)?,
+        })
+    }
+}
+
+impl<Ar, Ac> StrictEncode for PublicOffer<Ar, Ac>
+where
+    Ar: Arbitrating,
+    Ac: Accordant,
+{
+    fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, strict_encoding::Error> {
+        Encodable::consensus_encode(self, &mut e).map_err(strict_encoding::Error::from)
+    }
+}
+
+impl<Ar, Ac> StrictDecode for PublicOffer<Ar, Ac>
+where
+    Ar: Arbitrating,
+    Ac: Accordant,
+{
+    fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, strict_encoding::Error> {
+        Decodable::consensus_decode(&mut d).map_err(|_| {
+            strict_encoding::Error::DataIntegrityError(
+                "Failed to decode the public offer".to_string(),
+            )
         })
     }
 }


### PR DESCRIPTION
Light alternative to #18 (without `FromStr` impl.)