### PR TITLE
Remove generic Asset Encodable/Decodable and disambiguates asset from amount of assets

### DIFF
--- a/chains/tests/negotiation.rs
+++ b/chains/tests/negotiation.rs
@@ -18,10 +18,10 @@ fn create_offer() {
                10800090000000000000002";
     let offer: Offer<BtcXmr> = Offer {
         network: Network::Testnet,
-        arbitrating: Bitcoin::new(),
-        accordant: Monero::new(),
-        arbitrating_assets: Amount::from_sat(5),
-        accordant_assets: 6,
+        arbitrating_blockchain: Bitcoin::new(),
+        accordant_blockchain: Monero::new(),
+        arbitrating_amount: Amount::from_sat(5),
+        accordant_amount: 6,
         cancel_timelock: CSVTimelock::new(7),
         punish_timelock: CSVTimelock::new(8),
         fee_strategy: FeeStrategy::Fixed(SatPerVByte::from_sat(9)),

--- a/core/src/blockchain.rs
+++ b/core/src/blockchain.rs
@@ -31,7 +31,7 @@ pub trait Timelock {
 
 /// Defines the asset identifier for a blockchain and its associated asset unit type, it is carried
 /// in the [Offer](crate::negotiation::Offer) to fix exchanged amounts.
-pub trait Asset: Copy + Debug + Encodable + Decodable {
+pub trait Asset: Copy + Debug {
     /// Type for the traded asset unit for a blockchain.
     type AssetUnit: Copy + Debug + Encodable + Decodable;
 
@@ -46,24 +46,6 @@ pub trait Asset: Copy + Debug + Encodable + Decodable {
     /// Return the 32 bits identifier for the blockchain as defined in [SLIP
     /// 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md#slip-0044--registered-coin-types-for-bip-0044).
     fn to_u32(&self) -> u32;
-}
-
-// FIXME this is too large and produce bad error messages
-impl<T: Asset> Encodable for T {
-    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        self.to_u32().consensus_encode(writer)
-    }
-}
-
-impl<T: Asset> Decodable for T {
-    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
-        let identifier: u32 = Decodable::consensus_decode(d)?;
-        // Follows Farcaster RFC 10
-        if identifier == 0x80000001 {
-            return Err(consensus::Error::UnknownType);
-        }
-        Self::from_u32(identifier).ok_or(consensus::Error::UnknownType)
-    }
 }
 
 /// Defines the types a blockchain needs to interact onchain, i.e. the transaction types.

--- a/core/src/negotiation.rs
+++ b/core/src/negotiation.rs
@@ -116,8 +116,8 @@ where
 {
     fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
         let mut len = self.network.consensus_encode(writer)?;
-        len += self.arbitrating.consensus_encode(writer)?;
-        len += self.accordant.consensus_encode(writer)?;
+        len += self.arbitrating.to_u32().consensus_encode(writer)?;
+        len += self.accordant.to_u32().consensus_encode(writer)?;
         len += wrap_in_vec!(wrap arbitrating_assets for self in writer);
         len += wrap_in_vec!(wrap accordant_assets for self in writer);
         len += wrap_in_vec!(wrap cancel_timelock for self in writer);
@@ -134,8 +134,10 @@ where
     fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
         Ok(Offer {
             network: Decodable::consensus_decode(d)?,
-            arbitrating: Decodable::consensus_decode(d)?,
-            accordant: Decodable::consensus_decode(d)?,
+            arbitrating: Ctx::Ar::from_u32(Decodable::consensus_decode(d)?)
+                .ok_or(consensus::Error::UnknownType)?,
+            accordant: Ctx::Ac::from_u32(Decodable::consensus_decode(d)?)
+                .ok_or(consensus::Error::UnknownType)?,
             arbitrating_assets: unwrap_from_vec!(d),
             accordant_assets: unwrap_from_vec!(d),
             cancel_timelock: unwrap_from_vec!(d),


### PR DESCRIPTION
The generic implementation:

```rust
impl<T: Asset> Encodable for T {
    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
        self.to_u32().consensus_encode(writer)
    }
}
```
It was generating bad error message as if Asset is implemented on a type `Encodable` and `Decodable` is too. This has to be fixed.

Field names in `Offer` as been improved as asked in #25 