### PR TITLE
Add blanket implementation for Arbitrating and Accordant traits

### DIFF
--- a/chains/src/bitcoin/mod.rs
+++ b/chains/src/bitcoin/mod.rs
@@ -14,7 +14,7 @@ use strict_encoding::{StrictDecode, StrictEncode};
 use farcaster_core::blockchain::{self, Asset, Onchain, Timelock, Transactions};
 use farcaster_core::consensus::{self, Decodable, Encodable};
 use farcaster_core::crypto::{ArbitratingKey, Commitment, FromSeed, Keys, Signatures};
-use farcaster_core::role::{Arb, Arbitrating};
+use farcaster_core::role::Arb;
 
 use transaction::{Buy, Cancel, Funding, Lock, Punish, Refund, Tx};
 
@@ -116,8 +116,6 @@ impl Timelock for Bitcoin {
     /// Defines the type of timelock used for the arbitrating transactions
     type Timelock = CSVTimelock;
 }
-
-impl Arbitrating for Bitcoin {}
 
 #[derive(Debug, Clone, StrictDecode, StrictEncode)]
 pub struct Address(pub bitcoin::Address);

--- a/chains/src/monero/mod.rs
+++ b/chains/src/monero/mod.rs
@@ -4,7 +4,7 @@ use farcaster_core::blockchain::Asset;
 use farcaster_core::crypto::{
     AccordantKey, Commitment, FromSeed, Keys, SharedPrivateKey, SharedPrivateKeys,
 };
-use farcaster_core::role::{Acc, Accordant};
+use farcaster_core::role::Acc;
 
 use monero::cryptonote::hash::Hash;
 use monero::util::key::{PrivateKey, PublicKey};
@@ -54,8 +54,6 @@ impl Asset for Monero {
         0x80000080
     }
 }
-
-impl Accordant for Monero {}
 
 impl Keys for Monero {
     /// Private key type for the blockchain

--- a/core/src/role.rs
+++ b/core/src/role.rs
@@ -682,10 +682,31 @@ pub trait Arbitrating:
 {
 }
 
+impl<T> Arbitrating for T where
+    T: Asset
+        + Address
+        + Commitment
+        + Fee
+        + FromSeed<Arb>
+        + Keys
+        + Onchain
+        + Signatures
+        + Timelock
+        + Transactions
+        + Clone
+        + Eq
+{
+}
+
 /// An accordant is the blockchain which does not need transaction inside the protocol nor
 /// timelocks, it is the blockchain with the less requirements for an atomic swap.
 pub trait Accordant:
     Asset + Keys + Commitment + SharedPrivateKeys<Acc> + FromSeed<Acc> + Clone + Eq
+{
+}
+
+impl<T> Accordant for T where
+    T: Asset + Keys + Commitment + SharedPrivateKeys<Acc> + FromSeed<Acc> + Clone + Eq
 {
 }
 


### PR DESCRIPTION
No need anymore to write:
```rust
impl Arbitrating for Bitcoin {}
```
The trait is implemented if all the conditions are required.