### PR TITLE
Move commit from Arb/Acc to Swap

### DIFF
--- a/chains/src/bitcoin/mod.rs
+++ b/chains/src/bitcoin/mod.rs
@@ -1,7 +1,5 @@
 //! Defines and implements all the traits for Bitcoin
 
-use bitcoin::hash_types::PubkeyHash;
-use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::secp256k1::Signature;
 use bitcoin::util::amount;
@@ -13,7 +11,7 @@ use strict_encoding::{StrictDecode, StrictEncode};
 
 use farcaster_core::blockchain::{self, Asset, Onchain, Timelock, Transactions};
 use farcaster_core::consensus::{self, Decodable, Encodable};
-use farcaster_core::crypto::{self, ArbitratingKey, Commitment, FromSeed, Keys, Signatures};
+use farcaster_core::crypto::{self, ArbitratingKey, FromSeed, Keys, Signatures};
 use farcaster_core::role::{Arb, Arbitrating};
 
 use transaction::{Buy, Cancel, Funding, Lock, Punish, Refund, Tx};
@@ -243,14 +241,6 @@ impl Keys for Bitcoin {
 
     fn as_bytes(pubkey: &PublicKey) -> Vec<u8> {
         pubkey.to_bytes()
-    }
-}
-
-impl Commitment for Bitcoin {
-    type Commitment = PubkeyHash;
-
-    fn commit_to<T: AsRef<[u8]>>(value: T) -> PubkeyHash {
-        PubkeyHash::hash(value.as_ref())
     }
 }
 

--- a/chains/src/monero/mod.rs
+++ b/chains/src/monero/mod.rs
@@ -2,7 +2,7 @@
 
 use farcaster_core::blockchain::Asset;
 use farcaster_core::crypto::{
-    self, AccordantKey, Commitment, FromSeed, Keys, SharedPrivateKey, SharedPrivateKeys,
+    self, AccordantKey, FromSeed, Keys, SharedPrivateKey, SharedPrivateKeys,
 };
 use farcaster_core::role::{Acc, Accordant};
 
@@ -87,14 +87,6 @@ impl SharedPrivateKeys<Acc> for Monero {
 
     fn as_bytes(privkey: &PrivateKey) -> Vec<u8> {
         privkey.as_bytes().into()
-    }
-}
-
-impl Commitment for Monero {
-    type Commitment = Hash;
-
-    fn commit_to<T: AsRef<[u8]>>(value: T) -> Hash {
-        Hash::hash(value.as_ref())
     }
 }
 

--- a/chains/src/pairs/btcxmr.rs
+++ b/chains/src/pairs/btcxmr.rs
@@ -1,10 +1,12 @@
 use strict_encoding::{StrictDecode, StrictEncode};
 
-use farcaster_core::crypto::{self, DleqProof};
+use farcaster_core::crypto::{self, Commitment, DleqProof};
 use farcaster_core::swap::Swap;
 
 use crate::bitcoin::Bitcoin;
 use crate::monero::{private_spend_from_seed, Monero};
+
+use monero::cryptonote::hash::Hash;
 
 use bitcoin::secp256k1::key::SecretKey;
 use bitcoin::secp256k1::Secp256k1;
@@ -21,6 +23,14 @@ impl Swap for BtcXmr {
 
     /// The proof system to link both cryptographic groups
     type Proof = RingProof;
+}
+
+impl Commitment for BtcXmr {
+    type Commitment = Hash;
+
+    fn commit_to<T: AsRef<[u8]>>(value: T) -> Hash {
+        Hash::hash(value.as_ref())
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/core/src/crypto.rs
+++ b/core/src/crypto.rs
@@ -207,13 +207,13 @@ where
     fn as_bytes(privkey: &Self::SharedPrivateKey) -> Vec<u8>;
 }
 
-/// This trait is required for blockchains for fixing the commitment types of the keys.
+/// This trait is required for blockchains for fixing the commitment types of the keys and
+/// parameters that must go through the commit/reveal scheme at the beginning of the protocol.
 pub trait Commitment {
     /// Commitment type used in the commit/reveal scheme during swap parameters setup.
     type Commitment: Clone + PartialEq + Eq + Debug + StrictEncode + StrictDecode;
 
     /// Provides a generic method to commit to any value referencable as stream of bytes.
-    //fn commit_to(value: Self::PublicKey) -> Self::Commitment;
     fn commit_to<T: AsRef<[u8]>>(value: T) -> Self::Commitment;
 
     /// Validate the equality between a value and a commitment, return ok if the value commits to

--- a/core/src/protocol_message.rs
+++ b/core/src/protocol_message.rs
@@ -5,7 +5,7 @@ use strict_encoding::{StrictDecode, StrictEncode};
 
 use crate::blockchain::{Address, Onchain};
 use crate::bundle;
-use crate::crypto::{Commitment, DleqProof, Keys, SharedPrivateKeys, SignatureType, Signatures};
+use crate::crypto::{DleqProof, Keys, SharedPrivateKeys, SignatureType, Signatures};
 use crate::datum;
 use crate::role::{Acc, SwapRole};
 use crate::swap::Swap;
@@ -21,19 +21,19 @@ pub trait ProtocolMessage: StrictEncode + StrictDecode {}
 #[strict_encoding_crate(strict_encoding)]
 pub struct CommitAliceParameters<Ctx: Swap> {
     /// Commitment to `Ab` curve point
-    pub buy: <Ctx::Ar as Commitment>::Commitment,
+    pub buy: Ctx::Commitment,
     /// Commitment to `Ac` curve point
-    pub cancel: <Ctx::Ar as Commitment>::Commitment,
+    pub cancel: Ctx::Commitment,
     /// Commitment to `Ar` curve point
-    pub refund: <Ctx::Ar as Commitment>::Commitment,
+    pub refund: Ctx::Commitment,
     /// Commitment to `Ap` curve point
-    pub punish: <Ctx::Ar as Commitment>::Commitment,
+    pub punish: Ctx::Commitment,
     /// Commitment to `Ta` curve point
-    pub adaptor: <Ctx::Ar as Commitment>::Commitment,
+    pub adaptor: Ctx::Commitment,
     /// Commitment to `k_v^a` scalar
-    pub spend: <Ctx::Ac as Commitment>::Commitment,
+    pub spend: Ctx::Commitment,
     /// Commitment to `K_s^a` curve point
-    pub view: <Ctx::Ac as Commitment>::Commitment,
+    pub view: Ctx::Commitment,
 }
 
 impl<Ctx> CommitAliceParameters<Ctx>
@@ -42,49 +42,46 @@ where
 {
     pub fn from_bundle(bundle: &bundle::AliceParameters<Ctx>) -> Self {
         Self {
-            buy: <Ctx::Ar as Commitment>::commit_to(bundle.buy.key().as_bytes()),
-            cancel: <Ctx::Ar as Commitment>::commit_to(bundle.cancel.key().as_bytes()),
-            refund: <Ctx::Ar as Commitment>::commit_to(bundle.refund.key().as_bytes()),
-            punish: <Ctx::Ar as Commitment>::commit_to(bundle.punish.key().as_bytes()),
-            adaptor: <Ctx::Ar as Commitment>::commit_to(bundle.adaptor.key().as_bytes()),
-            spend: <Ctx::Ac as Commitment>::commit_to(bundle.spend.key().as_bytes()),
-            view: <Ctx::Ac as Commitment>::commit_to(bundle.view.key().as_bytes()),
+            buy: Ctx::commit_to(bundle.buy.key().as_bytes()),
+            cancel: Ctx::commit_to(bundle.cancel.key().as_bytes()),
+            refund: Ctx::commit_to(bundle.refund.key().as_bytes()),
+            punish: Ctx::commit_to(bundle.punish.key().as_bytes()),
+            adaptor: Ctx::commit_to(bundle.adaptor.key().as_bytes()),
+            spend: Ctx::commit_to(bundle.spend.key().as_bytes()),
+            view: Ctx::commit_to(bundle.view.key().as_bytes()),
         }
     }
 
     pub fn verify(&self, reveal: &RevealAliceParameters<Ctx>) -> Result<(), Error> {
         // Check buy commitment
-        <Ctx::Ar as Commitment>::validate(
-            <Ctx::Ar as Keys>::as_bytes(&reveal.buy),
-            self.buy.clone(),
-        )?;
+        Ctx::validate(<Ctx::Ar as Keys>::as_bytes(&reveal.buy), self.buy.clone())?;
         // Check cancel commitment
-        <Ctx::Ar as Commitment>::validate(
+        Ctx::validate(
             <Ctx::Ar as Keys>::as_bytes(&reveal.cancel),
             self.cancel.clone(),
         )?;
         // Check refund commitment
-        <Ctx::Ar as Commitment>::validate(
+        Ctx::validate(
             <Ctx::Ar as Keys>::as_bytes(&reveal.refund),
             self.refund.clone(),
         )?;
         // Check punish commitment
-        <Ctx::Ar as Commitment>::validate(
+        Ctx::validate(
             <Ctx::Ar as Keys>::as_bytes(&reveal.punish),
             self.punish.clone(),
         )?;
         // Check adaptor commitment
-        <Ctx::Ar as Commitment>::validate(
+        Ctx::validate(
             <Ctx::Ar as Keys>::as_bytes(&reveal.adaptor),
             self.adaptor.clone(),
         )?;
         // Check spend commitment
-        <Ctx::Ac as Commitment>::validate(
+        Ctx::validate(
             <Ctx::Ac as Keys>::as_bytes(&reveal.spend),
             self.spend.clone(),
         )?;
         // Check private view commitment
-        <Ctx::Ac as Commitment>::validate(
+        Ctx::validate(
             <Ctx::Ac as SharedPrivateKeys<Acc>>::as_bytes(&reveal.view),
             self.view.clone(),
         )?;
@@ -122,17 +119,17 @@ impl<Ctx> ProtocolMessage for CommitAliceParameters<Ctx> where Ctx: Swap {}
 #[strict_encoding_crate(strict_encoding)]
 pub struct CommitBobParameters<Ctx: Swap> {
     /// Commitment to `Bb` curve point
-    pub buy: <Ctx::Ar as Commitment>::Commitment,
+    pub buy: Ctx::Commitment,
     /// Commitment to `Bc` curve point
-    pub cancel: <Ctx::Ar as Commitment>::Commitment,
+    pub cancel: Ctx::Commitment,
     /// Commitment to `Br` curve point
-    pub refund: <Ctx::Ar as Commitment>::Commitment,
+    pub refund: Ctx::Commitment,
     /// Commitment to `Tb` curve point
-    pub adaptor: <Ctx::Ar as Commitment>::Commitment,
+    pub adaptor: Ctx::Commitment,
     /// Commitment to `k_v^b` scalar
-    pub spend: <Ctx::Ac as Commitment>::Commitment,
+    pub spend: Ctx::Commitment,
     /// Commitment to `K_s^b` curve point
-    pub view: <Ctx::Ac as Commitment>::Commitment,
+    pub view: Ctx::Commitment,
 }
 
 impl<Ctx> CommitBobParameters<Ctx>
@@ -141,43 +138,40 @@ where
 {
     pub fn from_bundle(bundle: &bundle::BobParameters<Ctx>) -> Self {
         Self {
-            buy: <Ctx::Ar as Commitment>::commit_to(bundle.buy.key().as_bytes()),
-            cancel: <Ctx::Ar as Commitment>::commit_to(bundle.cancel.key().as_bytes()),
-            refund: <Ctx::Ar as Commitment>::commit_to(bundle.refund.key().as_bytes()),
-            adaptor: <Ctx::Ar as Commitment>::commit_to(bundle.adaptor.key().as_bytes()),
-            spend: <Ctx::Ac as Commitment>::commit_to(bundle.spend.key().as_bytes()),
-            view: <Ctx::Ac as Commitment>::commit_to(bundle.view.key().as_bytes()),
+            buy: Ctx::commit_to(bundle.buy.key().as_bytes()),
+            cancel: Ctx::commit_to(bundle.cancel.key().as_bytes()),
+            refund: Ctx::commit_to(bundle.refund.key().as_bytes()),
+            adaptor: Ctx::commit_to(bundle.adaptor.key().as_bytes()),
+            spend: Ctx::commit_to(bundle.spend.key().as_bytes()),
+            view: Ctx::commit_to(bundle.view.key().as_bytes()),
         }
     }
 
     pub fn verify(&self, reveal: &RevealBobParameters<Ctx>) -> Result<(), Error> {
         // Check buy commitment
-        <Ctx::Ar as Commitment>::validate(
-            <Ctx::Ar as Keys>::as_bytes(&reveal.buy),
-            self.buy.clone(),
-        )?;
+        Ctx::validate(<Ctx::Ar as Keys>::as_bytes(&reveal.buy), self.buy.clone())?;
         // Check cancel commitment
-        <Ctx::Ar as Commitment>::validate(
+        Ctx::validate(
             <Ctx::Ar as Keys>::as_bytes(&reveal.cancel),
             self.cancel.clone(),
         )?;
         // Check refund commitment
-        <Ctx::Ar as Commitment>::validate(
+        Ctx::validate(
             <Ctx::Ar as Keys>::as_bytes(&reveal.refund),
             self.refund.clone(),
         )?;
         // Check adaptor commitment
-        <Ctx::Ar as Commitment>::validate(
+        Ctx::validate(
             <Ctx::Ar as Keys>::as_bytes(&reveal.adaptor),
             self.adaptor.clone(),
         )?;
         // Check spend commitment
-        <Ctx::Ac as Commitment>::validate(
+        Ctx::validate(
             <Ctx::Ac as Keys>::as_bytes(&reveal.spend),
             self.spend.clone(),
         )?;
         // Check private view commitment
-        <Ctx::Ac as Commitment>::validate(
+        Ctx::validate(
             <Ctx::Ac as SharedPrivateKeys<Acc>>::as_bytes(&reveal.view),
             self.view.clone(),
         )?;

--- a/core/src/role.rs
+++ b/core/src/role.rs
@@ -12,8 +12,8 @@ use crate::bundle::{
 };
 use crate::consensus::{self, Decodable, Encodable};
 use crate::crypto::{
-    AccordantKey, ArbitratingKey, Commitment, DleqProof, FromSeed, Keys, SharedPrivateKey,
-    SharedPrivateKeys, SignatureType, Signatures,
+    AccordantKey, ArbitratingKey, DleqProof, FromSeed, Keys, SharedPrivateKey, SharedPrivateKeys,
+    SignatureType, Signatures,
 };
 use crate::datum::{self, Key, Parameter, Proof, Signature};
 use crate::negotiation::PublicOffer;
@@ -1222,7 +1222,6 @@ impl<Ctx: Swap> Bob<Ctx> {
 pub trait Arbitrating:
     Asset
     + Address
-    + Commitment
     + Fee
     + FromSeed<Arb>
     + Keys
@@ -1237,10 +1236,7 @@ pub trait Arbitrating:
 
 /// An accordant is the blockchain which does not need transaction inside the protocol nor
 /// timelocks, it is the blockchain with the less requirements for an atomic swap.
-pub trait Accordant:
-    Asset + Keys + Commitment + SharedPrivateKeys<Acc> + FromSeed<Acc> + Clone + Eq
-{
-}
+pub trait Accordant: Asset + Keys + SharedPrivateKeys<Acc> + FromSeed<Acc> + Clone + Eq {}
 
 /// Defines the role of a blockchain. Farcaster uses two blockchain roles (1) [Arbitrating] and (2)
 /// [Accordant].

--- a/core/src/swap.rs
+++ b/core/src/swap.rs
@@ -2,12 +2,12 @@
 
 use std::fmt::Debug;
 
-use crate::crypto::DleqProof;
+use crate::crypto::{Commitment, DleqProof};
 use crate::role::{Accordant, Arbitrating};
 
 /// Specifie the context of a swap, fixing the arbitrating blockchain, the accordant blockchain and
 /// the link between them.
-pub trait Swap: Debug + Clone {
+pub trait Swap: Debug + Clone + Commitment {
     /// The arbitrating blockchain concrete implementation used for the swap.
     type Ar: Arbitrating;
 


### PR DESCRIPTION
Commit trait was implemented on each chain, meaning every chain can choose what to use as a hash, now the commit is under the context, a commit/reveal scheme is define per blockchain pairs.