### PR TITLE
Change how encoding is handled

### DIFF
--- a/chains/src/bitcoin/transaction/buy.rs
+++ b/chains/src/bitcoin/transaction/buy.rs
@@ -1,12 +1,13 @@
 use bitcoin::blockdata::script::Instruction;
 use bitcoin::util::key::PublicKey;
 use bitcoin::util::psbt::PartiallySignedTransaction;
+use bitcoin::Address;
 
 use farcaster_core::script;
 use farcaster_core::transaction::{Buyable, Error as FError, Lockable};
 
 use crate::bitcoin::transaction::{Error, MetadataOutput, SubTransaction, Tx};
-use crate::bitcoin::{Address, Bitcoin};
+use crate::bitcoin::Bitcoin;
 
 #[derive(Debug)]
 pub struct Buy;

--- a/chains/src/bitcoin/transaction/funding.rs
+++ b/chains/src/bitcoin/transaction/funding.rs
@@ -1,12 +1,13 @@
 use bitcoin::blockdata::transaction::{OutPoint, Transaction};
 use bitcoin::network::constants::Network as BtcNetwork;
 use bitcoin::util::key::PublicKey;
+use bitcoin::Address;
 
 use farcaster_core::blockchain::Network;
 use farcaster_core::transaction::{Error as FError, Fundable, Linkable};
 
 use crate::bitcoin::transaction::{Error, MetadataOutput};
-use crate::bitcoin::{Address, Bitcoin};
+use crate::bitcoin::Bitcoin;
 
 #[derive(Debug, Clone)]
 pub struct Funding {
@@ -80,15 +81,15 @@ impl Fundable<Bitcoin, MetadataOutput> for Funding {
         }?;
 
         match self.network {
-            Some(Network::Mainnet) => Ok(Address(
-                bitcoin::Address::p2wpkh(&pubkey, BtcNetwork::Bitcoin).map_err(Error::from)?,
-            )),
-            Some(Network::Testnet) => Ok(Address(
-                bitcoin::Address::p2wpkh(&pubkey, BtcNetwork::Testnet).map_err(Error::from)?,
-            )),
-            Some(Network::Local) => Ok(Address(
-                bitcoin::Address::p2wpkh(&pubkey, BtcNetwork::Regtest).map_err(Error::from)?,
-            )),
+            Some(Network::Mainnet) => {
+                Ok(bitcoin::Address::p2wpkh(&pubkey, BtcNetwork::Bitcoin).map_err(Error::from)?)
+            }
+            Some(Network::Testnet) => {
+                Ok(bitcoin::Address::p2wpkh(&pubkey, BtcNetwork::Testnet).map_err(Error::from)?)
+            }
+            Some(Network::Local) => {
+                Ok(bitcoin::Address::p2wpkh(&pubkey, BtcNetwork::Regtest).map_err(Error::from)?)
+            }
             None => Err(FError::MissingNetwork),
         }
     }

--- a/chains/src/bitcoin/transaction/punish.rs
+++ b/chains/src/bitcoin/transaction/punish.rs
@@ -1,10 +1,11 @@
 use bitcoin::util::psbt::PartiallySignedTransaction;
+use bitcoin::Address;
 
 use farcaster_core::script;
 use farcaster_core::transaction::{Cancelable, Error, Punishable};
 
 use crate::bitcoin::transaction::{MetadataOutput, SubTransaction, Tx};
-use crate::bitcoin::{Address, Bitcoin};
+use crate::bitcoin::Bitcoin;
 
 #[derive(Debug)]
 pub struct Punish;

--- a/chains/src/bitcoin/transaction/refund.rs
+++ b/chains/src/bitcoin/transaction/refund.rs
@@ -2,12 +2,13 @@ use std::marker::PhantomData;
 
 use bitcoin::blockdata::transaction::{SigHashType, TxIn, TxOut};
 use bitcoin::util::psbt::PartiallySignedTransaction;
+use bitcoin::Address;
 
 use farcaster_core::script;
 use farcaster_core::transaction::{Cancelable, Error as FError, Refundable};
 
 use crate::bitcoin::transaction::{Error, MetadataOutput, SubTransaction, Tx};
-use crate::bitcoin::{Address, Bitcoin};
+use crate::bitcoin::Bitcoin;
 
 #[derive(Debug)]
 pub struct Refund;
@@ -37,7 +38,7 @@ impl Refundable<Bitcoin, MetadataOutput> for Tx<Refund> {
             }],
             output: vec![TxOut {
                 value: output_metadata.tx_out.value,
-                script_pubkey: refund_target.0.script_pubkey(),
+                script_pubkey: refund_target.script_pubkey(),
             }],
         };
 

--- a/core/src/blockchain.rs
+++ b/core/src/blockchain.rs
@@ -65,6 +65,14 @@ pub trait Onchain {
 
     /// Defines the finalized transaction format for the arbitrating blockchain
     type Transaction: Clone + Debug + StrictEncode + StrictDecode;
+
+    fn partial_as_bytes(data: &Self::PartialTransaction) -> Result<Vec<u8>, io::Error>;
+
+    fn partial_from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self::PartialTransaction, consensus::Error>;
+
+    fn tx_as_bytes(data: &Self::Transaction) -> Result<Vec<u8>, io::Error>;
+
+    fn tx_from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self::Transaction, consensus::Error>;
 }
 
 /// Fix the types for all arbitrating transactions needed for the swap: [Fundable], [Lockable],

--- a/core/src/blockchain.rs
+++ b/core/src/blockchain.rs
@@ -20,14 +20,22 @@ use crate::transaction::{Buyable, Cancelable, Fundable, Lockable, Punishable, Re
 /// Defines the type for a blockchain address, this type is used when manipulating transactions.
 pub trait Address {
     /// Defines the address format for the arbitrating blockchain.
-    type Address: Clone + Debug + Encodable + Decodable + StrictEncode + StrictDecode;
+    type Address: Clone + Debug + StrictEncode + StrictDecode;
+
+    fn as_bytes(data: &Self::Address) -> Result<Vec<u8>, io::Error>;
+
+    fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self::Address, consensus::Error>;
 }
 
 /// Defines the type for a blockchain timelock, this type is used when manipulating transactions
 /// and is carried in the [Offer](crate::negotiation::Offer) to fix the two timelocks.
 pub trait Timelock {
     /// Defines the type of timelock used for the arbitrating transactions.
-    type Timelock: Copy + Debug + Encodable + Decodable + PartialEq + Eq;
+    type Timelock: Copy + PartialEq + Eq + Debug;
+
+    fn as_bytes(data: &Self::Timelock) -> Result<Vec<u8>, io::Error>;
+
+    fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self::Timelock, consensus::Error>;
 }
 
 /// Defines the asset identifier for a blockchain and its associated asset unit type, it is carried

--- a/core/src/negotiation.rs
+++ b/core/src/negotiation.rs
@@ -128,8 +128,8 @@ where
             .consensus_encode(writer)?;
         len += wrap_in_vec!(wrap arbitrating_amount for self in writer);
         len += wrap_in_vec!(wrap accordant_amount for self in writer);
-        len += wrap_in_vec!(wrap cancel_timelock for self in writer);
-        len += wrap_in_vec!(wrap punish_timelock for self in writer);
+        len += <Ctx::Ar as Timelock>::as_bytes(&self.cancel_timelock)?.consensus_encode(writer)?;
+        len += <Ctx::Ar as Timelock>::as_bytes(&self.punish_timelock)?.consensus_encode(writer)?;
         len += self.fee_strategy.consensus_encode(writer)?;
         Ok(len + self.maker_role.consensus_encode(writer)?)
     }
@@ -148,8 +148,8 @@ where
                 .ok_or(consensus::Error::UnknownType)?,
             arbitrating_amount: unwrap_from_vec!(d),
             accordant_amount: unwrap_from_vec!(d),
-            cancel_timelock: unwrap_from_vec!(d),
-            punish_timelock: unwrap_from_vec!(d),
+            cancel_timelock: <Ctx::Ar as Timelock>::from_bytes(Vec::<u8>::consensus_decode(d)?)?,
+            punish_timelock: <Ctx::Ar as Timelock>::from_bytes(Vec::<u8>::consensus_decode(d)?)?,
             fee_strategy: Decodable::consensus_decode(d)?,
             maker_role: Decodable::consensus_decode(d)?,
         })


### PR DESCRIPTION
This will change how Farcaster encoding and `strict_encoding` is handled within `core` lib.

Now we have
```rust
trait Timelock {
    type Timelock: Encodable + Decodable;
}
```

This requires in `chains` to have a type that implements Farcaster consensus encoding and strict encoding but allows in `core` to derive `strict_encode` for messages.

When types comes from upstream library, e.g. rust-bitcoin or monero-rs, they don't `impl` the traits specified and wrappers are created:
```rust
pub struct Address(bitcoin::Address);

impl Encodable for Address { ... }
impl Decodable for Address { ... }
```
 
The goal is to replace the example above with:
```rust
trait Timelock {
    type Timelock;

    fn to_bytes(data: &Self::Timelock) -> Result<Vec<u8>, io::Error>;
    fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self::Timelock, consensus::Error>;
}
```
as bytes and from bytes will be on all traits that require serialization of associated types. Farcaster encoding is handled directly in `core` and `strict_encoding` is wrapped around consensus, no need to have external types implementing it directly.

The implementation in `chain` is cleaner, but methods `to_bytes` and `from_bytes` will be defined on 5-8 traits IMO, and we can't move them into it's own trait without introducing cycling dependencies.