### PR TITLE
Rework general handling of encoding in core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ internet2 = "0.3.10"
 
 # blockchain specific
 bitcoin = "0.26"
-monero = { version = "0.13", features = ["strict_encoding_support"] }
+monero = { version = "0.13" }
 
 [dev-dependencies]
 bitcoincore-rpc = "0.13.0"

--- a/run-rpc-tests.sh
+++ b/run-rpc-tests.sh
@@ -4,11 +4,10 @@ ID=$(docker run --rm -d -p 18443:18443 coblox/bitcoin-core\
     -regtest\
     -server\
     -rpcbind=0.0.0.0\
-     -rpcallowip=0.0.0.0/0\
+    -rpcallowip=0.0.0.0/0\
     -rpcuser=test\
     -rpcpassword=cEl2o3tHHgzYeuu3CiiZ2FjdgSiw9wNeMFzoNbFmx9k=)
 
-RPC_HOST=127.0.0.1 RPC_PORT=18443 RPC_USER=ci RPC_PASS=cEl2o3tHHgzYeuu3CiiZ2FjdgSiw9wNeMFzoNbFmx9k= cargo test --test transactions --features rpc -- --test-threads=1 --nocapture
-
+RPC_HOST=127.0.0.1 RPC_PORT=18443 RPC_USER=test RPC_PASS=cEl2o3tHHgzYeuu3CiiZ2FjdgSiw9wNeMFzoNbFmx9k= cargo test --test transactions --features rpc -- --test-threads=1
 
 docker kill $ID

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 
 use thiserror::Error;
 
-use crate::consensus::{self, CanonicalBytes, Decodable, Encodable};
+use crate::consensus::{self, deserialize, serialize, CanonicalBytes, Decodable, Encodable};
 use crate::crypto::{Keys, Signatures};
 use crate::transaction::{Buyable, Cancelable, Fundable, Lockable, Punishable, Refundable};
 
@@ -145,6 +145,27 @@ where
     }
 }
 
+impl<T> CanonicalBytes for FeeStrategy<T>
+where
+    T: Clone + PartialOrd + PartialEq + Debug + CanonicalBytes,
+{
+    fn as_canonical_bytes(&self) -> Vec<u8> {
+        serialize(self)
+    }
+
+    fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, consensus::Error>
+    where
+        Self: Sized,
+    {
+        deserialize(bytes)
+    }
+}
+
+impl_strict_encoding!(
+    FeeStrategy<T>,
+    T: Clone + PartialOrd + PartialEq + CanonicalBytes
+);
+
 /// Define the type of errors a fee strategy can encounter during calculation, application, and
 /// validation of fees on a partial transaction.
 #[derive(Error, Debug)]
@@ -268,3 +289,5 @@ impl Decodable for Network {
         }
     }
 }
+
+impl_strict_encoding!(Network);

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -18,7 +18,7 @@ use crate::transaction::{Buyable, Cancelable, Fundable, Lockable, Punishable, Re
 /// Defines the type for a blockchain address, this type is used when manipulating transactions.
 pub trait Address {
     /// Defines the address format for the arbitrating blockchain.
-    type Address: Clone + Debug;
+    type Address: Clone + Debug + Encodable + Decodable;
 }
 
 /// Defines the type for a blockchain timelock, this type is used when manipulating transactions

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -11,28 +11,28 @@ use std::str::FromStr;
 
 use thiserror::Error;
 
-use crate::consensus::{self, Decodable, Encodable};
+use crate::consensus::{self, CanonicalBytes, Decodable, Encodable};
 use crate::crypto::{Keys, Signatures};
 use crate::transaction::{Buyable, Cancelable, Fundable, Lockable, Punishable, Refundable};
 
 /// Defines the type for a blockchain address, this type is used when manipulating transactions.
 pub trait Address {
     /// Defines the address format for the arbitrating blockchain.
-    type Address: Clone + Debug + Encodable + Decodable;
+    type Address: Clone + Debug + CanonicalBytes;
 }
 
 /// Defines the type for a blockchain timelock, this type is used when manipulating transactions
 /// and is carried in the [Offer](crate::negotiation::Offer) to fix the two timelocks.
 pub trait Timelock {
     /// Defines the type of timelock used for the arbitrating transactions.
-    type Timelock: Copy + Debug + Encodable + Decodable + PartialEq + Eq;
+    type Timelock: Copy + Debug + CanonicalBytes + PartialEq + Eq;
 }
 
 /// Defines the asset identifier for a blockchain and its associated asset unit type, it is carried
 /// in the [Offer](crate::negotiation::Offer) to fix exchanged amounts.
 pub trait Asset: Copy + Debug {
     /// Type for the traded asset unit for a blockchain.
-    type AssetUnit: Copy + Eq + Debug + Encodable + Decodable;
+    type AssetUnit: Copy + Eq + Debug + CanonicalBytes;
 
     /// Parse an 32 bits identifier as defined in [SLIP
     /// 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md#slip-0044--registered-coin-types-for-bip-0044)
@@ -48,10 +48,10 @@ pub trait Asset: Copy + Debug {
 pub trait Onchain {
     /// Defines the transaction format used to transfer partial transaction between participant for
     /// the arbitrating blockchain
-    type PartialTransaction: Clone + Debug;
+    type PartialTransaction: Clone + Debug + CanonicalBytes;
 
     /// Defines the finalized transaction format for the arbitrating blockchain
-    type Transaction: Clone + Debug;
+    type Transaction: Clone + Debug + CanonicalBytes;
 }
 
 /// Fix the types for all arbitrating transactions needed for the swap: [Fundable], [Lockable],
@@ -78,7 +78,7 @@ pub trait Transactions: Timelock + Address + Fee + Keys + Signatures + Sized {
 
 impl<T> FromStr for FeeStrategy<T>
 where
-    T: Clone + PartialOrd + PartialEq + Encodable + Decodable + FromStr,
+    T: Clone + PartialOrd + PartialEq + CanonicalBytes + FromStr,
 {
     type Err = consensus::Error;
 
@@ -99,7 +99,7 @@ where
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum FeeStrategy<T>
 where
-    T: Clone + PartialOrd + PartialEq + Encodable + Decodable,
+    T: Clone + PartialOrd + PartialEq + CanonicalBytes,
 {
     /// A fixed strategy with the exact amount to set
     Fixed(T),
@@ -109,18 +109,18 @@ where
 
 impl<T> Encodable for FeeStrategy<T>
 where
-    T: Clone + PartialOrd + PartialEq + Encodable + Decodable,
+    T: Clone + PartialOrd + PartialEq + CanonicalBytes,
 {
     fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
         match self {
             FeeStrategy::Fixed(t) => {
                 0x01u8.consensus_encode(writer)?;
-                Ok(wrap_in_vec!(wrap t in writer) + 1)
+                Ok(t.as_canonical_bytes().consensus_encode(writer)? + 1)
             }
             FeeStrategy::Range(Range { start, end }) => {
-                0x02u8.consensus_encode(writer)?;
-                let len = wrap_in_vec!(wrap start in writer);
-                Ok(wrap_in_vec!(wrap end in writer) + len + 1)
+                let mut len = 0x02u8.consensus_encode(writer)?;
+                len += start.as_canonical_bytes().consensus_encode(writer)?;
+                Ok(len + end.as_canonical_bytes().consensus_encode(writer)?)
             }
         }
     }
@@ -128,14 +128,16 @@ where
 
 impl<T> Decodable for FeeStrategy<T>
 where
-    T: Clone + PartialOrd + PartialEq + Encodable + Decodable,
+    T: Clone + PartialOrd + PartialEq + CanonicalBytes,
 {
     fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
         match Decodable::consensus_decode(d)? {
-            0x01u8 => Ok(FeeStrategy::Fixed(unwrap_from_vec!(d))),
+            0x01u8 => Ok(FeeStrategy::Fixed(T::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?)),
             0x02u8 => {
-                let start = unwrap_from_vec!(d);
-                let end = unwrap_from_vec!(d);
+                let start = T::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?;
+                let end = T::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?;
                 Ok(FeeStrategy::Range(Range { start, end }))
             }
             _ => Err(consensus::Error::UnknownType),
@@ -204,7 +206,7 @@ pub enum FeePolitic {
 /// transactions.
 pub trait Fee: Onchain + Asset {
     /// Type for describing the fee of a blockchain
-    type FeeUnit: Clone + Debug + PartialOrd + PartialEq + Encodable + Decodable + PartialEq + Eq;
+    type FeeUnit: Clone + PartialOrd + PartialEq + Eq + Debug + CanonicalBytes;
 
     /// Calculates and sets the fee on the given transaction and return the amount of fee set in
     /// the blockchain native amount format.

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -3,7 +3,10 @@
 //! Datum are succinct and are used to convey atomic chunk of data (datum) between clients and
 //! daemons. Bundles are used during the different steps of the swap by both Alice and Bob.
 
+use std::io;
+
 use crate::blockchain::{Address, Fee, FeeStrategy, Onchain, Timelock};
+use crate::consensus::{self, CanonicalBytes, Decodable, Encodable};
 use crate::crypto::{Keys, SharedKeyId, SharedPrivateKeys, Signatures, TaggedElement};
 use crate::protocol_message;
 use crate::swap::Swap;
@@ -30,6 +33,69 @@ pub struct AliceParameters<Ctx: Swap> {
     pub punish_timelock: Option<<Ctx::Ar as Timelock>::Timelock>,
     pub fee_strategy: Option<FeeStrategy<<Ctx::Ar as Fee>::FeeUnit>>,
 }
+
+impl<Ctx> Encodable for AliceParameters<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let mut len = self.buy.as_canonical_bytes().consensus_encode(s)?;
+        len += self.cancel.as_canonical_bytes().consensus_encode(s)?;
+        len += self.refund.as_canonical_bytes().consensus_encode(s)?;
+        len += self.punish.as_canonical_bytes().consensus_encode(s)?;
+        len += self.adaptor.as_canonical_bytes().consensus_encode(s)?;
+        len += self.extra_arbitrating_keys.consensus_encode(s)?;
+        len += self.arbitrating_shared_keys.consensus_encode(s)?;
+        len += self.spend.as_canonical_bytes().consensus_encode(s)?;
+        len += self.extra_accordant_keys.consensus_encode(s)?;
+        len += self.accordant_shared_keys.consensus_encode(s)?;
+        len += self
+            .destination_address
+            .as_canonical_bytes()
+            .consensus_encode(s)?;
+        len += self.proof.as_canonical_bytes().consensus_encode(s)?;
+        len += self.cancel_timelock.consensus_encode(s)?;
+        len += self.punish_timelock.consensus_encode(s)?;
+        Ok(len + self.fee_strategy.consensus_encode(s)?)
+    }
+}
+
+impl<Ctx> Decodable for AliceParameters<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            buy: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            cancel: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            refund: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            punish: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            adaptor: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            extra_arbitrating_keys: Decodable::consensus_decode(d)?,
+            arbitrating_shared_keys: Decodable::consensus_decode(d)?,
+            spend: <Ctx::Ac as Keys>::PublicKey::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            extra_accordant_keys: Decodable::consensus_decode(d)?,
+            accordant_shared_keys: Decodable::consensus_decode(d)?,
+            destination_address: <Ctx::Ar as Address>::Address::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            proof: Ctx::Proof::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            cancel_timelock: Decodable::consensus_decode(d)?,
+            punish_timelock: Decodable::consensus_decode(d)?,
+            fee_strategy: Decodable::consensus_decode(d)?,
+        })
+    }
+}
+
+impl_strict_encoding!(AliceParameters<Ctx>, Ctx: Swap);
 
 impl<Ctx> From<protocol_message::RevealAliceParameters<Ctx>> for AliceParameters<Ctx>
 where
@@ -78,6 +144,64 @@ pub struct BobParameters<Ctx: Swap> {
     pub fee_strategy: Option<FeeStrategy<<Ctx::Ar as Fee>::FeeUnit>>,
 }
 
+impl<Ctx> Encodable for BobParameters<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let mut len = self.buy.as_canonical_bytes().consensus_encode(s)?;
+        len += self.cancel.as_canonical_bytes().consensus_encode(s)?;
+        len += self.refund.as_canonical_bytes().consensus_encode(s)?;
+        len += self.adaptor.as_canonical_bytes().consensus_encode(s)?;
+        len += self.extra_arbitrating_keys.consensus_encode(s)?;
+        len += self.arbitrating_shared_keys.consensus_encode(s)?;
+        len += self.extra_accordant_keys.consensus_encode(s)?;
+        len += self.accordant_shared_keys.consensus_encode(s)?;
+        len += self
+            .refund_address
+            .as_canonical_bytes()
+            .consensus_encode(s)?;
+        len += self.proof.as_canonical_bytes().consensus_encode(s)?;
+        len += self.cancel_timelock.consensus_encode(s)?;
+        len += self.punish_timelock.consensus_encode(s)?;
+        Ok(len + self.fee_strategy.consensus_encode(s)?)
+    }
+}
+
+impl<Ctx> Decodable for BobParameters<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            buy: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            cancel: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            refund: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            adaptor: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            extra_arbitrating_keys: Decodable::consensus_decode(d)?,
+            arbitrating_shared_keys: Decodable::consensus_decode(d)?,
+            spend: <Ctx::Ac as Keys>::PublicKey::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            extra_accordant_keys: Decodable::consensus_decode(d)?,
+            accordant_shared_keys: Decodable::consensus_decode(d)?,
+            refund_address: <Ctx::Ar as Address>::Address::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            proof: Ctx::Proof::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            cancel_timelock: Decodable::consensus_decode(d)?,
+            punish_timelock: Decodable::consensus_decode(d)?,
+            fee_strategy: Decodable::consensus_decode(d)?,
+        })
+    }
+}
+
+impl_strict_encoding!(BobParameters<Ctx>, Ctx: Swap);
+
 impl<Ctx> From<protocol_message::RevealBobParameters<Ctx>> for BobParameters<Ctx>
 where
     Ctx: Swap,
@@ -116,6 +240,28 @@ where
     pub cancel_sig: S::Signature,
 }
 
+impl<S> Encodable for CosignedArbitratingCancel<S>
+where
+    S: Signatures,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        self.cancel_sig.as_canonical_bytes().consensus_encode(s)
+    }
+}
+
+impl<S> Decodable for CosignedArbitratingCancel<S>
+where
+    S: Signatures,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            cancel_sig: S::Signature::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+        })
+    }
+}
+
+impl_strict_encoding!(CosignedArbitratingCancel<S>, S: Signatures);
+
 impl<Ctx> From<protocol_message::CoreArbitratingSetup<Ctx>> for CosignedArbitratingCancel<Ctx::Ar>
 where
     Ctx: Swap,
@@ -148,6 +294,28 @@ where
     pub funding: T::Transaction,
 }
 
+impl<T> Encodable for FundingTransaction<T>
+where
+    T: Onchain,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        self.funding.as_canonical_bytes().consensus_encode(s)
+    }
+}
+
+impl<T> Decodable for FundingTransaction<T>
+where
+    T: Onchain,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            funding: T::Transaction::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+        })
+    }
+}
+
+impl_strict_encoding!(FundingTransaction<T>, T: Onchain);
+
 /// Provides Bob's daemon or Alice's clients the core set of arbritrating transactions.
 #[derive(Debug, Clone)]
 pub struct CoreArbitratingTransactions<T>
@@ -158,6 +326,32 @@ where
     pub cancel: T::PartialTransaction,
     pub refund: T::PartialTransaction,
 }
+
+impl<T> Encodable for CoreArbitratingTransactions<T>
+where
+    T: Onchain,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let mut len = self.lock.as_canonical_bytes().consensus_encode(s)?;
+        len += self.cancel.as_canonical_bytes().consensus_encode(s)?;
+        Ok(len + self.refund.as_canonical_bytes().consensus_encode(s)?)
+    }
+}
+
+impl<T> Decodable for CoreArbitratingTransactions<T>
+where
+    T: Onchain,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            lock: T::PartialTransaction::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            cancel: T::PartialTransaction::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            refund: T::PartialTransaction::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+        })
+    }
+}
+
+impl_strict_encoding!(CoreArbitratingTransactions<T>, T: Onchain);
 
 impl<Ctx> From<protocol_message::CoreArbitratingSetup<Ctx>> for CoreArbitratingTransactions<Ctx::Ar>
 where
@@ -183,6 +377,36 @@ where
     pub buy_adaptor_sig: T::AdaptorSignature,
 }
 
+impl<T> Encodable for SignedAdaptorBuy<T>
+where
+    T: Signatures + Onchain,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let len = self.buy.as_canonical_bytes().consensus_encode(s)?;
+        Ok(len
+            + self
+                .buy_adaptor_sig
+                .as_canonical_bytes()
+                .consensus_encode(s)?)
+    }
+}
+
+impl<T> Decodable for SignedAdaptorBuy<T>
+where
+    T: Signatures + Onchain,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            buy: T::PartialTransaction::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            buy_adaptor_sig: T::AdaptorSignature::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+        })
+    }
+}
+
+impl_strict_encoding!(SignedAdaptorBuy<T>, T: Signatures + Onchain);
+
 /// Provides Alice's daemon or Bob's clients with the two signatures on the unsigned buy (c)
 /// transaction.
 #[derive(Debug, Clone)]
@@ -194,6 +418,34 @@ where
     pub buy_adapted_sig: S::Signature,
 }
 
+impl<S> Encodable for FullySignedBuy<S>
+where
+    S: Signatures,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let len = self.buy_sig.as_canonical_bytes().consensus_encode(s)?;
+        Ok(len
+            + self
+                .buy_adapted_sig
+                .as_canonical_bytes()
+                .consensus_encode(s)?)
+    }
+}
+
+impl<S> Decodable for FullySignedBuy<S>
+where
+    S: Signatures,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            buy_sig: S::Signature::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            buy_adapted_sig: S::Signature::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+        })
+    }
+}
+
+impl_strict_encoding!(FullySignedBuy<S>, S: Signatures);
+
 /// Provides Alice's daemon or Bob's clients with a signature on the unsigned refund (e)
 /// transaction.
 #[derive(Debug, Clone)]
@@ -203,6 +455,32 @@ where
 {
     pub refund_adaptor_sig: S::AdaptorSignature,
 }
+
+impl<S> Encodable for SignedAdaptorRefund<S>
+where
+    S: Signatures,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        self.refund_adaptor_sig
+            .as_canonical_bytes()
+            .consensus_encode(s)
+    }
+}
+
+impl<S> Decodable for SignedAdaptorRefund<S>
+where
+    S: Signatures,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            refund_adaptor_sig: S::AdaptorSignature::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+        })
+    }
+}
+
+impl_strict_encoding!(SignedAdaptorRefund<S>, S: Signatures);
 
 impl<Ctx> From<protocol_message::RefundProcedureSignatures<Ctx>> for SignedAdaptorRefund<Ctx::Ar>
 where
@@ -226,6 +504,34 @@ where
     pub refund_adapted_sig: S::Signature,
 }
 
+impl<S> Encodable for FullySignedRefund<S>
+where
+    S: Signatures,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let len = self.refund_sig.as_canonical_bytes().consensus_encode(s)?;
+        Ok(len
+            + self
+                .refund_adapted_sig
+                .as_canonical_bytes()
+                .consensus_encode(s)?)
+    }
+}
+
+impl<S> Decodable for FullySignedRefund<S>
+where
+    S: Signatures,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            refund_sig: S::Signature::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            refund_adapted_sig: S::Signature::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+        })
+    }
+}
+
+impl_strict_encoding!(FullySignedRefund<S>, S: Signatures);
+
 /// Provides Bob's daemon with the signature on the unsigned lock (b) transaction.
 #[derive(Debug, Clone)]
 pub struct SignedArbitratingLock<S>
@@ -234,6 +540,28 @@ where
 {
     pub lock_sig: S::Signature,
 }
+
+impl<S> Encodable for SignedArbitratingLock<S>
+where
+    S: Signatures,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        self.lock_sig.as_canonical_bytes().consensus_encode(s)
+    }
+}
+
+impl<S> Decodable for SignedArbitratingLock<S>
+where
+    S: Signatures,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            lock_sig: S::Signature::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+        })
+    }
+}
+
+impl_strict_encoding!(SignedArbitratingLock<S>, S: Signatures);
 
 /// Provides Alice's daemon with the signature on the unsigned punish (f) transaction.
 #[derive(Debug, Clone)]
@@ -244,3 +572,27 @@ where
     pub punish: T::PartialTransaction,
     pub punish_sig: T::Signature,
 }
+
+impl<T> Encodable for FullySignedPunish<T>
+where
+    T: Signatures + Onchain,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let len = self.punish.as_canonical_bytes().consensus_encode(s)?;
+        Ok(len + self.punish_sig.as_canonical_bytes().consensus_encode(s)?)
+    }
+}
+
+impl<T> Decodable for FullySignedPunish<T>
+where
+    T: Signatures + Onchain,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            punish: T::PartialTransaction::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            punish_sig: T::Signature::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+        })
+    }
+}
+
+impl_strict_encoding!(FullySignedPunish<T>, T: Signatures + Onchain);

--- a/src/chain/bitcoin/address.rs
+++ b/src/chain/bitcoin/address.rs
@@ -1,21 +1,20 @@
-use crate::consensus::{self, Decodable, Encodable};
+use crate::consensus::{self, CanonicalBytes};
 use bitcoin::Address;
 
-use std::io;
-use std::str::FromStr;
+use std::str::{self, FromStr};
 
-impl Encodable for Address {
-    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        bitcoin::consensus::encode::Encodable::consensus_encode(&self.to_string(), writer)
+impl CanonicalBytes for Address {
+    fn as_canonical_bytes(&self) -> Vec<u8> {
+        self.to_string().into()
     }
-}
 
-impl Decodable for Address {
-    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
-        let bytes: String = bitcoin::consensus::encode::Decodable::consensus_decode(d)
-            .map_err(|_| consensus::Error::ParseFailed("Bitcoin address parsing failed"))?;
-        let add: bitcoin::Address = FromStr::from_str(&bytes)
-            .map_err(|_| consensus::Error::ParseFailed("Bitcoin address parsing failed"))?;
-        Ok(add)
+    fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, consensus::Error>
+    where
+        Self: Sized,
+    {
+        Ok(
+            Address::from_str(str::from_utf8(bytes).map_err(consensus::Error::new)?)
+                .map_err(consensus::Error::new)?,
+        )
     }
 }

--- a/src/chain/bitcoin/fee.rs
+++ b/src/chain/bitcoin/fee.rs
@@ -1,7 +1,6 @@
 use bitcoin::blockdata::transaction::TxOut;
 use bitcoin::util::psbt::PartiallySignedTransaction;
 use bitcoin::Amount;
-use strict_encoding::{StrictDecode, StrictEncode};
 
 use crate::blockchain::{Fee, FeePolitic, FeeStrategy, FeeStrategyError};
 use crate::consensus::{self, CanonicalBytes};
@@ -11,7 +10,7 @@ use crate::chain::bitcoin::Bitcoin;
 
 use std::str::FromStr;
 
-#[derive(Debug, Clone, PartialOrd, PartialEq, Eq, StrictDecode, StrictEncode)]
+#[derive(Debug, Clone, PartialOrd, PartialEq, Eq)]
 pub struct SatPerVByte(Amount);
 
 impl SatPerVByte {

--- a/src/chain/bitcoin/fee.rs
+++ b/src/chain/bitcoin/fee.rs
@@ -4,12 +4,11 @@ use bitcoin::Amount;
 use strict_encoding::{StrictDecode, StrictEncode};
 
 use crate::blockchain::{Fee, FeePolitic, FeeStrategy, FeeStrategyError};
-use crate::consensus::{self, Decodable, Encodable};
+use crate::consensus::{self, CanonicalBytes};
 
 use crate::chain::bitcoin::transaction;
 use crate::chain::bitcoin::Bitcoin;
 
-use std::io;
 use std::str::FromStr;
 
 #[derive(Debug, Clone, PartialOrd, PartialEq, Eq, StrictDecode, StrictEncode)]
@@ -29,16 +28,18 @@ impl SatPerVByte {
     }
 }
 
-impl Encodable for SatPerVByte {
-    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        self.0.consensus_encode(writer)
+impl CanonicalBytes for SatPerVByte {
+    fn as_canonical_bytes(&self) -> Vec<u8> {
+        bitcoin::consensus::encode::serialize(&self.0.as_sat())
     }
-}
 
-impl Decodable for SatPerVByte {
-    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
-        let amount: Amount = Decodable::consensus_decode(d)?;
-        Ok(SatPerVByte(amount))
+    fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, consensus::Error>
+    where
+        Self: Sized,
+    {
+        Ok(SatPerVByte(Amount::from_sat(
+            bitcoin::consensus::encode::deserialize(bytes).map_err(consensus::Error::new)?,
+        )))
     }
 }
 

--- a/src/chain/bitcoin/timelock.rs
+++ b/src/chain/bitcoin/timelock.rs
@@ -1,5 +1,3 @@
-use strict_encoding::{StrictDecode, StrictEncode};
-
 use crate::consensus::{self, CanonicalBytes};
 
 use std::fmt::Debug;
@@ -16,7 +14,7 @@ impl FromStr for CSVTimelock {
     }
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Clone, Debug, StrictDecode, StrictEncode, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Clone, Debug, Copy)]
 pub struct CSVTimelock(u32);
 
 impl CSVTimelock {

--- a/src/chain/bitcoin/transaction/mod.rs
+++ b/src/chain/bitcoin/transaction/mod.rs
@@ -13,6 +13,7 @@ use bitcoin::Amount;
 
 use thiserror::Error;
 
+use crate::consensus::{self, CanonicalBytes};
 use crate::script::ScriptPath;
 use crate::transaction::{
     Broadcastable, Error as FError, Finalizable, Linkable, Transaction, Witnessable,
@@ -232,6 +233,32 @@ impl<'a> TxInRef<'a> {
 impl<'a> AsRef<TxIn> for TxInRef<'a> {
     fn as_ref(&self) -> &TxIn {
         self.input()
+    }
+}
+
+impl CanonicalBytes for bitcoin::Transaction {
+    fn as_canonical_bytes(&self) -> Vec<u8> {
+        bitcoin::consensus::encode::serialize(&self)
+    }
+
+    fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, consensus::Error>
+    where
+        Self: Sized,
+    {
+        bitcoin::consensus::encode::deserialize(bytes).map_err(consensus::Error::new)
+    }
+}
+
+impl CanonicalBytes for PartiallySignedTransaction {
+    fn as_canonical_bytes(&self) -> Vec<u8> {
+        bitcoin::consensus::encode::serialize(&self)
+    }
+
+    fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, consensus::Error>
+    where
+        Self: Sized,
+    {
+        bitcoin::consensus::encode::deserialize(bytes).map_err(consensus::Error::new)
     }
 }
 

--- a/src/chain/pairs/btcxmr.rs
+++ b/src/chain/pairs/btcxmr.rs
@@ -1,7 +1,7 @@
-use crate::crypto::{self, Commitment};
+use crate::consensus::{self, CanonicalBytes};
 use crate::crypto::{
-    AccordantKeyId, ArbitratingKeyId, Commit, GenerateKey, GenerateSharedKey, ProveCrossGroupDleq,
-    SharedKeyId, Sign,
+    self, AccordantKeyId, ArbitratingKeyId, Commit, Commitment, GenerateKey, GenerateSharedKey,
+    ProveCrossGroupDleq, SharedKeyId, Sign,
 };
 use crate::swap::Swap;
 
@@ -40,8 +40,34 @@ impl Commitment for BtcXmr {
     type Commitment = Hash;
 }
 
+impl CanonicalBytes for Hash {
+    fn as_canonical_bytes(&self) -> Vec<u8> {
+        self.to_bytes().into()
+    }
+
+    fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, consensus::Error>
+    where
+        Self: Sized,
+    {
+        Ok(Self::from_slice(bytes))
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct RingProof;
+
+impl CanonicalBytes for RingProof {
+    fn as_canonical_bytes(&self) -> Vec<u8> {
+        vec![0u8]
+    }
+
+    fn from_canonical_bytes(_: &[u8]) -> Result<Self, consensus::Error>
+    where
+        Self: Sized,
+    {
+        Ok(Self)
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct Wallet {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -401,7 +401,7 @@ mod tests {
 
     #[test]
     fn simple_vec() {
-        let vec = vec![0xde, 0xad, 0xbe, 0xef];
+        let vec: Vec<u8> = vec![0xde, 0xad, 0xbe, 0xef];
         // len of 4 as u16 in little endian = 0400
         assert_eq!(serialize_hex(&vec), "0400deadbeef");
         // test max size vec

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -8,6 +8,7 @@
 use hex::encode as hex_encode;
 use thiserror::Error;
 
+use std::error;
 use std::io;
 
 /// Encoding and decoding errors and data transformation errors (when converting data from protocol
@@ -32,12 +33,47 @@ pub enum Error {
     /// Strict encoding error.
     #[error("Strict encoding error: {0}")]
     StrictEncoding(#[from] strict_encoding::Error),
+    /// Any Consensus error not part of this list.
+    #[error("Consensus error: {0}")]
+    Other(Box<dyn error::Error + Send + Sync>),
+}
+
+impl Error {
+    /// Creates a new transaction error of type other with an arbitrary payload.
+    pub fn new<E>(error: E) -> Self
+    where
+        E: Into<Box<dyn error::Error + Send + Sync>>,
+    {
+        Self::Other(error.into())
+    }
+
+    /// Consumes the `Error`, returning its inner error (if any).
+    ///
+    /// If this [`enum@Error`] was constructed via [`new`] then this function will return [`Some`],
+    /// otherwise it will return [`None`].
+    ///
+    /// [`new`]: Error::new
+    ///
+    pub fn into_inner(self) -> Option<Box<dyn error::Error + Send + Sync>> {
+        match self {
+            Self::Other(error) => Some(error),
+            _ => None,
+        }
+    }
 }
 
 /// Data that can be represented in a canonical bytes format.
-pub trait AsCanonicalBytes {
+///
+/// The implementer MUST use the strict encoding dictated by the blockchain consensus without any
+/// lenght prefix. Lenght prefix is done by Farcaster core after during the serialization.
+pub trait CanonicalBytes {
     /// Returns the canonical bytes representation of the element.
     fn as_canonical_bytes(&self) -> Vec<u8>;
+
+    /// Parse a normally canonical bytes representation of an element and return it.
+    fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, Error>
+    where
+        Self: Sized;
 }
 
 /// Encode an object into a vector
@@ -78,11 +114,7 @@ pub fn deserialize_partial<T: Decodable>(data: &[u8]) -> Result<(T, usize), Erro
     Ok((rv, consumed))
 }
 
-/// Data which can be encoded in a consensus-consistent way
-///
-/// **When implemented on foreign blockchain specific types such as `Amount` from the bitcoin
-/// crate, the implementer MUST use the strict encoding dictated by the blockchain consensus
-/// without any lenght prefix. Lenght prefix is done by Farcaster core after this serialization.**
+/// Data which can be encoded in a consensus-consistent way.
 pub trait Encodable {
     /// Encode an object with a well-defined format, should only ever error if
     /// the underlying encoder errors.
@@ -91,11 +123,7 @@ pub trait Encodable {
     fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error>;
 }
 
-/// Data which can be encoded in a consensus-consistent way
-///
-/// **When implemented on foreign blockchain specific types such as `Amount` from the bitcoin
-/// crate, the implementer MUST use the strict encoding dictated by the blockchain consensus
-/// without any lenght prefix. Lenght prefix is done by Farcaster core after this serialization.**
+/// Data which can be encoded in a consensus-consistent way.
 pub trait Decodable: Sized {
     /// Decode an object with a well-defined format
     fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, Error>;
@@ -142,25 +170,10 @@ impl Decodable for [u8; 6] {
     }
 }
 
-macro_rules! wrap_in_vec {
-    (wrap $name: ident in $writer: ident) => {{
-        let mut encoder = ::std::io::Cursor::new(vec![]);
-        $name.consensus_encode(&mut encoder)?;
-        encoder.into_inner().consensus_encode($writer)?
-    }};
-
-    (wrap $name: ident for $self: ident in $writer: ident) => {{
-        let mut encoder = ::std::io::Cursor::new(vec![]);
-        $self.$name.consensus_encode(&mut encoder)?;
-        encoder.into_inner().consensus_encode($writer)?
-    }};
-}
-
-macro_rules! unwrap_from_vec {
+macro_rules! unwrap_vec_ref {
     ($reader: ident) => {{
         let v: Vec<u8> = $crate::consensus::Decodable::consensus_decode($reader)?;
-        let mut reader = ::std::io::Cursor::new(v);
-        $crate::consensus::Decodable::consensus_decode(&mut reader)?
+        v
     }};
 }
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -2,10 +2,11 @@
 
 use std::error;
 use std::fmt::Debug;
+use std::io;
 
 use thiserror::Error;
 
-use crate::consensus::CanonicalBytes;
+use crate::consensus::{self, CanonicalBytes, Decodable, Encodable};
 
 /// List of cryptographic errors that can be encountered when processing cryptographic operation
 /// such as signatures, proofs, key derivation, or commitments.
@@ -81,6 +82,31 @@ where
     }
 }
 
+impl<T, E> Encodable for TaggedElement<T, E>
+where
+    T: Eq + Encodable,
+    E: CanonicalBytes,
+{
+    #[inline]
+    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+        let len = self.tag.consensus_encode(s)?;
+        Ok(len + self.elem.as_canonical_bytes().consensus_encode(s)?)
+    }
+}
+
+impl<T, E> Decodable for TaggedElement<T, E>
+where
+    T: Eq + Decodable,
+    E: CanonicalBytes,
+{
+    #[inline]
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        let tag = T::consensus_decode(d)?;
+        let elem = E::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?;
+        Ok(TaggedElement { tag, elem })
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum ArbitratingKeyId {
     Fund,
@@ -110,6 +136,20 @@ impl SharedKeyId {
     }
 }
 
+impl Encodable for SharedKeyId {
+    #[inline]
+    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+        self.0.consensus_encode(s)
+    }
+}
+
+impl Decodable for SharedKeyId {
+    #[inline]
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self(u16::consensus_decode(d)?))
+    }
+}
+
 /// This trait is required for blockchains to fix the concrete cryptographic key types. The public
 /// key associated type is shared across the network.
 pub trait Keys {
@@ -135,7 +175,7 @@ pub trait SharedPrivateKeys {
 /// parameters that must go through the commit/reveal scheme at the beginning of the protocol.
 pub trait Commitment {
     /// Commitment type used in the commit/reveal scheme during swap parameters setup.
-    type Commitment: Clone + PartialEq + Eq + Debug;
+    type Commitment: Clone + PartialEq + Eq + Debug + CanonicalBytes;
 }
 
 /// This trait is required for arbitrating blockchains for defining the types of messages,

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 
 use thiserror::Error;
 
-use crate::consensus::AsCanonicalBytes;
+use crate::consensus::CanonicalBytes;
 
 /// List of cryptographic errors that can be encountered when processing cryptographic operation
 /// such as signatures, proofs, key derivation, or commitments.
@@ -117,7 +117,7 @@ pub trait Keys {
     type PrivateKey;
 
     /// Public key type given the blockchain and the crypto engine.
-    type PublicKey: Clone + PartialEq + Debug + AsCanonicalBytes;
+    type PublicKey: Clone + PartialEq + Debug + CanonicalBytes;
 
     fn extra_keys() -> Vec<u16>;
 }
@@ -126,7 +126,7 @@ pub trait Keys {
 /// the network.
 pub trait SharedPrivateKeys {
     /// A shareable private key type used to parse non-transparent blockchain
-    type SharedPrivateKey: Clone + PartialEq + Debug + AsCanonicalBytes;
+    type SharedPrivateKey: Clone + PartialEq + Debug + CanonicalBytes;
 
     fn shared_keys() -> Vec<SharedKeyId>;
 }
@@ -147,11 +147,11 @@ pub trait Signatures {
     type Message: Clone + Debug;
 
     /// Defines the signature format for the arbitrating blockchain.
-    type Signature: Clone + Debug;
+    type Signature: Clone + Debug + CanonicalBytes;
 
     /// Defines the adaptor signature format for the arbitrating blockchain. Adaptor signature may
     /// have a different format from the signature depending on the cryptographic primitives used.
-    type AdaptorSignature: Clone + Debug;
+    type AdaptorSignature: Clone + Debug + CanonicalBytes;
 }
 
 pub trait Wallet<ArPublicKey, AcPublicKey, ArSharedKey, AcSharedKey, Proof>:

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,3 +1,7 @@
+use std::io;
+
+use crate::consensus::{self, Decodable, Encodable};
+
 pub trait EventCore {
     fn id(&self) -> i32;
 }
@@ -8,6 +12,26 @@ pub struct HeightChanged {
     pub block: Vec<u8>,
     pub height: u64,
 }
+
+impl Encodable for HeightChanged {
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let mut len = self.id.consensus_encode(s)?;
+        len += self.block.consensus_encode(s)?;
+        Ok(len + self.height.consensus_encode(s)?)
+    }
+}
+
+impl Decodable for HeightChanged {
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            id: i32::consensus_decode(d)?,
+            block: Vec::<u8>::consensus_decode(d)?,
+            height: u64::consensus_decode(d)?,
+        })
+    }
+}
+
+impl_strict_encoding!(HeightChanged);
 
 impl EventCore for HeightChanged {
     fn id(&self) -> i32 {

--- a/src/negotiation.rs
+++ b/src/negotiation.rs
@@ -1,7 +1,6 @@
 //! Negotiation phase utilities
 
 use internet2::RemoteNodeAddr;
-use strict_encoding::{StrictDecode, StrictEncode};
 use thiserror::Error;
 
 use std::io;
@@ -37,8 +36,8 @@ impl Version {
 }
 
 impl Encodable for Version {
-    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        self.to_u16().consensus_encode(writer)
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        self.to_u16().consensus_encode(s)
     }
 }
 
@@ -116,34 +115,28 @@ impl<Ctx> Encodable for Offer<Ctx>
 where
     Ctx: Swap,
 {
-    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut len = self.network.consensus_encode(writer)?;
-        len += self
-            .arbitrating_blockchain
-            .to_u32()
-            .consensus_encode(writer)?;
-        len += self
-            .accordant_blockchain
-            .to_u32()
-            .consensus_encode(writer)?;
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let mut len = self.network.consensus_encode(s)?;
+        len += self.arbitrating_blockchain.to_u32().consensus_encode(s)?;
+        len += self.accordant_blockchain.to_u32().consensus_encode(s)?;
         len += self
             .arbitrating_amount
             .as_canonical_bytes()
-            .consensus_encode(writer)?;
+            .consensus_encode(s)?;
         len += self
             .accordant_amount
             .as_canonical_bytes()
-            .consensus_encode(writer)?;
+            .consensus_encode(s)?;
         len += self
             .cancel_timelock
             .as_canonical_bytes()
-            .consensus_encode(writer)?;
+            .consensus_encode(s)?;
         len += self
             .punish_timelock
             .as_canonical_bytes()
-            .consensus_encode(writer)?;
-        len += self.fee_strategy.consensus_encode(writer)?;
-        Ok(len + self.maker_role.consensus_encode(writer)?)
+            .consensus_encode(s)?;
+        len += self.fee_strategy.consensus_encode(s)?;
+        Ok(len + self.maker_role.consensus_encode(s)?)
     }
 }
 
@@ -175,6 +168,8 @@ where
         })
     }
 }
+
+impl_strict_encoding!(Offer<Ctx>, Ctx: Swap);
 
 /// Helper to create an offer from an arbitrating asset buyer perspective.
 ///
@@ -393,8 +388,7 @@ where
     type Err = consensus::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let decoded =
-            hex::decode(s).map_err(|_| consensus::Error::ParseFailed("Hex decode failed"))?;
+        let decoded = hex::decode(s).map_err(consensus::Error::new)?;
         let mut res = std::io::Cursor::new(decoded);
         Decodable::consensus_decode(&mut res)
     }
@@ -404,11 +398,11 @@ impl<Ctx> Encodable for PublicOffer<Ctx>
 where
     Ctx: Swap,
 {
-    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut len = OFFER_MAGIC_BYTES.consensus_encode(writer)?;
-        len += self.version.consensus_encode(writer)?;
-        len += self.offer.consensus_encode(writer)?;
-        len += strict_encoding::StrictEncode::strict_encode(&self.daemon_service, writer).map_err(
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let mut len = OFFER_MAGIC_BYTES.consensus_encode(s)?;
+        len += self.version.consensus_encode(s)?;
+        len += self.offer.consensus_encode(s)?;
+        len += strict_encoding::StrictEncode::strict_encode(&self.daemon_service, s).map_err(
             |_| {
                 io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -433,49 +427,9 @@ where
             version: Decodable::consensus_decode(d)?,
             offer: Decodable::consensus_decode(d)?,
             daemon_service: strict_encoding::StrictDecode::strict_decode(d)
-                .map_err(|_| consensus::Error::ParseFailed("Failed to decode RemoteNodeAddr"))?,
+                .map_err(consensus::Error::new)?,
         })
     }
 }
 
-impl<Ctx> StrictEncode for PublicOffer<Ctx>
-where
-    Ctx: Swap,
-{
-    fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, strict_encoding::Error> {
-        Encodable::consensus_encode(self, &mut e).map_err(strict_encoding::Error::from)
-    }
-}
-
-impl<Ctx> StrictDecode for PublicOffer<Ctx>
-where
-    Ctx: Swap,
-{
-    fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, strict_encoding::Error> {
-        Decodable::consensus_decode(&mut d).map_err(|_| {
-            strict_encoding::Error::DataIntegrityError(
-                "Failed to decode the public offer".to_string(),
-            )
-        })
-    }
-}
-
-impl<Ctx> StrictEncode for Offer<Ctx>
-where
-    Ctx: Swap,
-{
-    fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, strict_encoding::Error> {
-        Encodable::consensus_encode(self, &mut e).map_err(strict_encoding::Error::from)
-    }
-}
-
-impl<Ctx> StrictDecode for Offer<Ctx>
-where
-    Ctx: Swap,
-{
-    fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, strict_encoding::Error> {
-        Decodable::consensus_decode(&mut d).map_err(|_| {
-            strict_encoding::Error::DataIntegrityError("Failed to decode the offer".to_string())
-        })
-    }
-}
+impl_strict_encoding!(PublicOffer<Ctx>, Ctx: Swap);

--- a/src/protocol_message.rs
+++ b/src/protocol_message.rs
@@ -2,14 +2,14 @@
 
 use crate::blockchain::{Address, Onchain};
 use crate::bundle;
-use crate::consensus::AsCanonicalBytes;
+use crate::consensus::CanonicalBytes;
 use crate::crypto::{
     self, Commit, Keys, SharedKeyId, SharedPrivateKeys, Signatures, TaggedElement,
 };
 use crate::swap::Swap;
 use crate::Error;
 
-fn commit_to_vec<T: Clone + Eq, K: AsCanonicalBytes, C: Clone + Eq>(
+fn commit_to_vec<T: Clone + Eq, K: CanonicalBytes, C: Clone + Eq>(
     wallet: &impl Commit<C>,
     keys: &Vec<TaggedElement<T, K>>,
 ) -> Vec<TaggedElement<T, C>> {
@@ -23,7 +23,7 @@ fn commit_to_vec<T: Clone + Eq, K: AsCanonicalBytes, C: Clone + Eq>(
         .collect()
 }
 
-fn verify_vec_of_commitments<T: Eq, K: AsCanonicalBytes, C: Clone + Eq>(
+fn verify_vec_of_commitments<T: Eq, K: CanonicalBytes, C: Clone + Eq>(
     wallet: &impl Commit<C>,
     keys: Vec<TaggedElement<T, K>>,
     commitments: &Vec<TaggedElement<T, C>>,

--- a/src/protocol_message.rs
+++ b/src/protocol_message.rs
@@ -1,8 +1,10 @@
 //! Protocol messages exchanged between swap daemons
 
+use std::io;
+
 use crate::blockchain::{Address, Onchain};
 use crate::bundle;
-use crate::consensus::CanonicalBytes;
+use crate::consensus::{self, CanonicalBytes, Decodable, Encodable};
 use crate::crypto::{
     self, Commit, Keys, SharedKeyId, SharedPrivateKeys, Signatures, TaggedElement,
 };
@@ -129,6 +131,46 @@ where
     }
 }
 
+impl<Ctx> Encodable for CommitAliceParameters<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let mut len = self.buy.as_canonical_bytes().consensus_encode(s)?;
+        len += self.cancel.as_canonical_bytes().consensus_encode(s)?;
+        len += self.refund.as_canonical_bytes().consensus_encode(s)?;
+        len += self.punish.as_canonical_bytes().consensus_encode(s)?;
+        len += self.adaptor.as_canonical_bytes().consensus_encode(s)?;
+        len += self.extra_arbitrating_keys.consensus_encode(s)?;
+        len += self.arbitrating_shared_keys.consensus_encode(s)?;
+        len += self.spend.as_canonical_bytes().consensus_encode(s)?;
+        len += self.extra_accordant_keys.consensus_encode(s)?;
+        Ok(len + self.accordant_shared_keys.consensus_encode(s)?)
+    }
+}
+
+impl<Ctx> Decodable for CommitAliceParameters<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            buy: Ctx::Commitment::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            cancel: Ctx::Commitment::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            refund: Ctx::Commitment::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            punish: Ctx::Commitment::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            adaptor: Ctx::Commitment::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            extra_arbitrating_keys: Decodable::consensus_decode(d)?,
+            arbitrating_shared_keys: Decodable::consensus_decode(d)?,
+            spend: Ctx::Commitment::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            extra_accordant_keys: Decodable::consensus_decode(d)?,
+            accordant_shared_keys: Decodable::consensus_decode(d)?,
+        })
+    }
+}
+
+impl_strict_encoding!(CommitAliceParameters<Ctx>, Ctx: Swap);
+
 /// `commit_bob_session_params` forces Bob to commit to the result of his cryptographic setup
 /// before receiving Alice's setup. This is done to remove adaptive behavior.
 #[derive(Clone, Debug)]
@@ -207,6 +249,44 @@ where
     }
 }
 
+impl<Ctx> Encodable for CommitBobParameters<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let mut len = self.buy.as_canonical_bytes().consensus_encode(s)?;
+        len += self.cancel.as_canonical_bytes().consensus_encode(s)?;
+        len += self.refund.as_canonical_bytes().consensus_encode(s)?;
+        len += self.adaptor.as_canonical_bytes().consensus_encode(s)?;
+        len += self.extra_arbitrating_keys.consensus_encode(s)?;
+        len += self.arbitrating_shared_keys.consensus_encode(s)?;
+        len += self.spend.as_canonical_bytes().consensus_encode(s)?;
+        len += self.extra_accordant_keys.consensus_encode(s)?;
+        Ok(len + self.accordant_shared_keys.consensus_encode(s)?)
+    }
+}
+
+impl<Ctx> Decodable for CommitBobParameters<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            buy: Ctx::Commitment::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            cancel: Ctx::Commitment::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            refund: Ctx::Commitment::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            adaptor: Ctx::Commitment::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            extra_arbitrating_keys: Decodable::consensus_decode(d)?,
+            arbitrating_shared_keys: Decodable::consensus_decode(d)?,
+            spend: Ctx::Commitment::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            extra_accordant_keys: Decodable::consensus_decode(d)?,
+            accordant_shared_keys: Decodable::consensus_decode(d)?,
+        })
+    }
+}
+
+impl_strict_encoding!(CommitBobParameters<Ctx>, Ctx: Swap);
+
 // TODO: Add more common data to reveal, e.g. help to ensure that both node uses the same value for
 // fee
 
@@ -241,6 +321,60 @@ pub struct RevealAliceParameters<Ctx: Swap> {
     /// Reveal the cross-group discrete logarithm zero-knowledge proof
     pub proof: Ctx::Proof,
 }
+
+impl<Ctx> Encodable for RevealAliceParameters<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let mut len = self.buy.as_canonical_bytes().consensus_encode(s)?;
+        len += self.cancel.as_canonical_bytes().consensus_encode(s)?;
+        len += self.refund.as_canonical_bytes().consensus_encode(s)?;
+        len += self.punish.as_canonical_bytes().consensus_encode(s)?;
+        len += self.adaptor.as_canonical_bytes().consensus_encode(s)?;
+        len += self.extra_arbitrating_keys.consensus_encode(s)?;
+        len += self.arbitrating_shared_keys.consensus_encode(s)?;
+        len += self.spend.as_canonical_bytes().consensus_encode(s)?;
+        len += self.extra_accordant_keys.consensus_encode(s)?;
+        len += self.accordant_shared_keys.consensus_encode(s)?;
+        len += self.address.as_canonical_bytes().consensus_encode(s)?;
+        Ok(len + self.proof.as_canonical_bytes().consensus_encode(s)?)
+    }
+}
+
+impl<Ctx> Decodable for RevealAliceParameters<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            buy: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            cancel: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            refund: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            punish: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            adaptor: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            extra_arbitrating_keys: Decodable::consensus_decode(d)?,
+            arbitrating_shared_keys: Decodable::consensus_decode(d)?,
+            spend: <Ctx::Ac as Keys>::PublicKey::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            extra_accordant_keys: Decodable::consensus_decode(d)?,
+            accordant_shared_keys: Decodable::consensus_decode(d)?,
+            address: <Ctx::Ar as Address>::Address::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            proof: Ctx::Proof::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+        })
+    }
+}
+
+impl_strict_encoding!(RevealAliceParameters<Ctx>, Ctx: Swap);
 
 impl<Ctx> From<bundle::AliceParameters<Ctx>> for RevealAliceParameters<Ctx>
 where
@@ -294,6 +428,56 @@ pub struct RevealBobParameters<Ctx: Swap> {
     pub proof: Ctx::Proof,
 }
 
+impl<Ctx> Encodable for RevealBobParameters<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let mut len = self.buy.as_canonical_bytes().consensus_encode(s)?;
+        len += self.cancel.as_canonical_bytes().consensus_encode(s)?;
+        len += self.refund.as_canonical_bytes().consensus_encode(s)?;
+        len += self.adaptor.as_canonical_bytes().consensus_encode(s)?;
+        len += self.extra_arbitrating_keys.consensus_encode(s)?;
+        len += self.arbitrating_shared_keys.consensus_encode(s)?;
+        len += self.spend.as_canonical_bytes().consensus_encode(s)?;
+        len += self.extra_accordant_keys.consensus_encode(s)?;
+        len += self.accordant_shared_keys.consensus_encode(s)?;
+        len += self.address.as_canonical_bytes().consensus_encode(s)?;
+        Ok(len + self.proof.as_canonical_bytes().consensus_encode(s)?)
+    }
+}
+
+impl<Ctx> Decodable for RevealBobParameters<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            buy: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            cancel: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            refund: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            adaptor: <Ctx::Ar as Keys>::PublicKey::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            extra_arbitrating_keys: Decodable::consensus_decode(d)?,
+            arbitrating_shared_keys: Decodable::consensus_decode(d)?,
+            spend: <Ctx::Ac as Keys>::PublicKey::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+            extra_accordant_keys: Decodable::consensus_decode(d)?,
+            accordant_shared_keys: Decodable::consensus_decode(d)?,
+            address: <Ctx::Ar as Address>::Address::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            proof: Ctx::Proof::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
+        })
+    }
+}
+
+impl_strict_encoding!(RevealBobParameters<Ctx>, Ctx: Swap);
+
 impl<Ctx> From<bundle::BobParameters<Ctx>> for RevealBobParameters<Ctx>
 where
     Ctx: Swap,
@@ -329,6 +513,42 @@ pub struct CoreArbitratingSetup<Ctx: Swap> {
     pub cancel_sig: <Ctx::Ar as Signatures>::Signature,
 }
 
+impl<Ctx> Encodable for CoreArbitratingSetup<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let mut len = self.lock.as_canonical_bytes().consensus_encode(s)?;
+        len += self.cancel.as_canonical_bytes().consensus_encode(s)?;
+        len += self.refund.as_canonical_bytes().consensus_encode(s)?;
+        Ok(len + self.cancel_sig.as_canonical_bytes().consensus_encode(s)?)
+    }
+}
+
+impl<Ctx> Decodable for CoreArbitratingSetup<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            lock: <Ctx::Ar as Onchain>::PartialTransaction::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            cancel: <Ctx::Ar as Onchain>::PartialTransaction::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            refund: <Ctx::Ar as Onchain>::PartialTransaction::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            cancel_sig: <Ctx::Ar as Signatures>::Signature::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+        })
+    }
+}
+
+impl_strict_encoding!(CoreArbitratingSetup<Ctx>, Ctx: Swap);
+
 impl<Ctx>
     From<(
         bundle::CoreArbitratingTransactions<Ctx::Ar>,
@@ -363,6 +583,38 @@ pub struct RefundProcedureSignatures<Ctx: Swap> {
     pub refund_adaptor_sig: <Ctx::Ar as Signatures>::AdaptorSignature,
 }
 
+impl<Ctx> Encodable for RefundProcedureSignatures<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let len = self.cancel_sig.as_canonical_bytes().consensus_encode(s)?;
+        Ok(len
+            + self
+                .refund_adaptor_sig
+                .as_canonical_bytes()
+                .consensus_encode(s)?)
+    }
+}
+
+impl<Ctx> Decodable for RefundProcedureSignatures<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            cancel_sig: <Ctx::Ar as Signatures>::Signature::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            refund_adaptor_sig: <Ctx::Ar as Signatures>::AdaptorSignature::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+        })
+    }
+}
+
+impl_strict_encoding!(RefundProcedureSignatures<Ctx>, Ctx: Swap);
+
 impl<Ctx>
     From<(
         bundle::CosignedArbitratingCancel<Ctx::Ar>,
@@ -395,6 +647,38 @@ pub struct BuyProcedureSignature<Ctx: Swap> {
     pub buy_adaptor_sig: <Ctx::Ar as Signatures>::AdaptorSignature,
 }
 
+impl<Ctx> Encodable for BuyProcedureSignature<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        let len = self.buy.as_canonical_bytes().consensus_encode(s)?;
+        Ok(len
+            + self
+                .buy_adaptor_sig
+                .as_canonical_bytes()
+                .consensus_encode(s)?)
+    }
+}
+
+impl<Ctx> Decodable for BuyProcedureSignature<Ctx>
+where
+    Ctx: Swap,
+{
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            buy: <Ctx::Ar as Onchain>::PartialTransaction::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+            buy_adaptor_sig: <Ctx::Ar as Signatures>::AdaptorSignature::from_canonical_bytes(
+                unwrap_vec_ref!(d).as_ref(),
+            )?,
+        })
+    }
+}
+
+impl_strict_encoding!(BuyProcedureSignature<Ctx>, Ctx: Swap);
+
 impl<Ctx> From<bundle::SignedAdaptorBuy<Ctx::Ar>> for BuyProcedureSignature<Ctx>
 where
     Ctx: Swap,
@@ -414,3 +698,19 @@ pub struct Abort {
     /// OPTIONAL `body`: error code | string
     pub error_body: Option<String>,
 }
+
+impl Encodable for Abort {
+    fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
+        self.error_body.consensus_encode(s)
+    }
+}
+
+impl Decodable for Abort {
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        Ok(Self {
+            error_body: Option::<String>::consensus_decode(d)?,
+        })
+    }
+}
+
+impl_strict_encoding!(Abort);

--- a/src/role.rs
+++ b/src/role.rs
@@ -46,6 +46,27 @@ impl NegotiationRole {
     }
 }
 
+impl Encodable for NegotiationRole {
+    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
+        match self {
+            NegotiationRole::Maker => 0x01u8.consensus_encode(writer),
+            NegotiationRole::Taker => 0x02u8.consensus_encode(writer),
+        }
+    }
+}
+
+impl Decodable for NegotiationRole {
+    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
+        match Decodable::consensus_decode(d)? {
+            0x01u8 => Ok(NegotiationRole::Maker),
+            0x02u8 => Ok(NegotiationRole::Taker),
+            _ => Err(consensus::Error::UnknownType),
+        }
+    }
+}
+
+impl_strict_encoding!(NegotiationRole);
+
 impl FromStr for NegotiationRole {
     type Err = consensus::Error;
 
@@ -66,13 +87,6 @@ impl ToString for NegotiationRole {
         }
     }
 }
-
-/// A maker is one that creates and share a public offer and start his daemon in listening mode so
-/// one taker can connect and start interacting with him.
-pub struct Maker;
-
-/// A taker parses offers and, if interested, connects to the peer registred in the offer.
-pub struct Taker;
 
 /// Defines the possible roles during the swap phase. When negotitation is done negotitation role
 /// will transition into swap role.
@@ -114,6 +128,8 @@ impl Decodable for SwapRole {
         }
     }
 }
+
+impl_strict_encoding!(SwapRole);
 
 impl FromStr for SwapRole {
     type Err = consensus::Error;

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::Debug;
 
+use crate::consensus::CanonicalBytes;
 use crate::crypto::Commitment;
 use crate::role::{Accordant, Arbitrating};
 
@@ -15,5 +16,5 @@ pub trait Swap: Debug + Clone + Commitment {
     type Ac: Accordant;
 
     ///// The concrete type to link both blockchain cryptographic groups used in by the signatures.
-    type Proof: Debug + Clone;
+    type Proof: Clone + Debug + CanonicalBytes;
 }


### PR DESCRIPTION
Rework of `CanonicalBytes`, `Encodable/Decodable` traits and `strict_encoding` in core.

This fix #27 and fix #26 in the previous PR.