### PR TITLE
Pin strict_encoding version and derive to comply with the node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ rpc = []
 
 [dependencies]
 hex = "0.4.3"
-strict_encoding = "=1.3.0"
+strict_encoding = "=1.2.3"
+strict_encoding_derive = "=1.0.0"
 thiserror = "1.0.24"
 internet2 = "0.3.10"
 


### PR DESCRIPTION
Pin versions to: 
```toml
strict_encoding = "=1.2.3"
strict_encoding_derive = "=1.0.0"
```
so `core` and `node` compiles with the current set of dependencies.