### PR TITLE
Implement traits for major structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2018"
 rpc = []
 
 [dependencies]
+amplify = "3.7.1"
 hex = "0.4.3"
 tiny-keccak = { version = "2", features = ["keccak"] }
 fixed-hash = { version = "0.7.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2018"
 
 [features]
 rpc = []
+serde = ["serde_crate", "bitcoin/use-serde", "monero/serde_support"]
 
 [dependencies]
 amplify = "3.7.1"
@@ -31,7 +32,7 @@ strict_encoding_derive = "=1.0.0"
 lightning_encoding = "0.4.0-beta.1"
 thiserror = "1.0.24"
 internet2 = "0.3.10"
-serde = "1"
+serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
 
 # blockchain specific
 bitcoin = "0.26"

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -98,6 +98,11 @@ where
 /// upon reception by the other participant.
 #[derive(Debug, Clone, Eq, PartialEq, Display)]
 #[display(fee_strategy_fmt)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub enum FeeStrategy<T>
 where
     T: Clone + PartialOrd + PartialEq + fmt::Display + CanonicalBytes,
@@ -225,6 +230,11 @@ impl FeeStrategyError {
 /// Defines how to set the fee when a strategy allows multiple possibilities.
 #[derive(Debug, Clone, Copy, Display)]
 #[display(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub enum FeePolitic {
     /// Set the fee at the minimum allowed by the strategy
     Aggressive,
@@ -273,6 +283,11 @@ impl FromStr for Network {
 /// blockchain.
 #[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Debug, Display)]
 #[display(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub enum Network {
     /// Represents a real asset on his valuable network
     Mainnet,

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -13,7 +13,8 @@ use crate::swap::Swap;
 
 /// Provides the (counter-party) daemon with all the information required for the initialization
 /// step of a swap.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
+#[display(Debug)]
 pub struct AliceParameters<Ctx: Swap> {
     pub buy: <Ctx::Ar as Keys>::PublicKey,
     pub cancel: <Ctx::Ar as Keys>::PublicKey,
@@ -124,7 +125,8 @@ where
 
 /// Provides the (counter-party) daemon with all the information required for the initialization
 /// step of a swap.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
+#[display(Debug)]
 pub struct BobParameters<Ctx: Swap> {
     pub buy: <Ctx::Ar as Keys>::PublicKey,
     pub cancel: <Ctx::Ar as Keys>::PublicKey,
@@ -233,7 +235,8 @@ where
 ///
 /// [`CoreArbitratingSetup`]: protocol_message::CoreArbitratingSetup
 /// [`RefundProcedureSignatures`]: protocol_message::RefundProcedureSignatures
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
+#[display("Cancel signature: {cancel_sig}")]
 pub struct CosignedArbitratingCancel<S>
 where
     S: Signatures,
@@ -287,12 +290,20 @@ where
 }
 
 /// Provides Bob's daemon the funding transaction for building the core arbritrating transactions.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
+#[display(funding_tx_fmt)]
 pub struct FundingTransaction<T>
 where
     T: Onchain,
 {
     pub funding: T::Transaction,
+}
+
+fn funding_tx_fmt<T>(b: &FundingTransaction<T>) -> String
+where
+    T: Onchain,
+{
+    format!("Funding transaction: {:?}", b.funding)
 }
 
 impl<T> Encodable for FundingTransaction<T>
@@ -318,7 +329,8 @@ where
 impl_strict_encoding!(FundingTransaction<T>, T: Onchain);
 
 /// Provides Bob's daemon or Alice's clients the core set of arbritrating transactions.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
+#[display(core_arbitrating_tx_fmt)]
 pub struct CoreArbitratingTransactions<T>
 where
     T: Onchain,
@@ -326,6 +338,16 @@ where
     pub lock: T::PartialTransaction,
     pub cancel: T::PartialTransaction,
     pub refund: T::PartialTransaction,
+}
+
+fn core_arbitrating_tx_fmt<T>(b: &CoreArbitratingTransactions<T>) -> String
+where
+    T: Onchain,
+{
+    format!(
+        "Lock: {:?}, Cancel: {:?}, Refund: {:?}",
+        b.lock, b.cancel, b.refund
+    )
 }
 
 impl<T> Encodable for CoreArbitratingTransactions<T>
@@ -369,13 +391,24 @@ where
 
 /// Provides Bob's daemon or Alice's client with an adaptor signature for the unsigned buy (c)
 /// transaction.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
+#[display(signed_adaptor_buy_fmt)]
 pub struct SignedAdaptorBuy<T>
 where
     T: Signatures + Onchain,
 {
     pub buy: T::PartialTransaction,
     pub buy_adaptor_sig: T::AdaptorSignature,
+}
+
+fn signed_adaptor_buy_fmt<T>(b: &SignedAdaptorBuy<T>) -> String
+where
+    T: Signatures + Onchain,
+{
+    format!(
+        "Buy partial: {:?}, Buy adaptor: {}",
+        b.buy, b.buy_adaptor_sig
+    )
 }
 
 impl<T> Encodable for SignedAdaptorBuy<T>
@@ -410,7 +443,8 @@ impl_strict_encoding!(SignedAdaptorBuy<T>, T: Signatures + Onchain);
 
 /// Provides Alice's daemon or Bob's clients with the two signatures on the unsigned buy (c)
 /// transaction.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
+#[display("Buy signature: {buy_sig}, Buy adapted: {buy_adapted_sig}")]
 pub struct FullySignedBuy<S>
 where
     S: Signatures,
@@ -449,7 +483,8 @@ impl_strict_encoding!(FullySignedBuy<S>, S: Signatures);
 
 /// Provides Alice's daemon or Bob's clients with a signature on the unsigned refund (e)
 /// transaction.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
+#[display("Refund adaptor: {refund_adaptor_sig}")]
 pub struct SignedAdaptorRefund<S>
 where
     S: Signatures,
@@ -496,7 +531,8 @@ where
 
 /// Provides Bob's daemon or Alice's clients with the two signatures on the unsigned refund (e)
 /// transaction.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
+#[display("Refund signature: {refund_sig}, Refund adapted: {refund_adapted_sig}")]
 pub struct FullySignedRefund<S>
 where
     S: Signatures,
@@ -534,7 +570,8 @@ where
 impl_strict_encoding!(FullySignedRefund<S>, S: Signatures);
 
 /// Provides Bob's daemon with the signature on the unsigned lock (b) transaction.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
+#[display("Lock signature: {lock_sig}")]
 pub struct SignedArbitratingLock<S>
 where
     S: Signatures,
@@ -565,13 +602,24 @@ where
 impl_strict_encoding!(SignedArbitratingLock<S>, S: Signatures);
 
 /// Provides Alice's daemon with the signature on the unsigned punish (f) transaction.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
+#[display(fully_signed_punish_fmt)]
 pub struct FullySignedPunish<T>
 where
     T: Signatures + Onchain,
 {
     pub punish: T::PartialTransaction,
     pub punish_sig: T::Signature,
+}
+
+fn fully_signed_punish_fmt<T>(b: &FullySignedPunish<T>) -> String
+where
+    T: Signatures + Onchain,
+{
+    format!(
+        "Punish partial: {:?}, Punish signature: {}",
+        b.punish, b.punish_sig
+    )
 }
 
 impl<T> Encodable for FullySignedPunish<T>

--- a/src/chain/bitcoin/fee.rs
+++ b/src/chain/bitcoin/fee.rs
@@ -10,7 +10,8 @@ use crate::chain::bitcoin::Bitcoin;
 
 use std::str::FromStr;
 
-#[derive(Debug, Clone, PartialOrd, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Display)]
+#[display("{0} per vByte")]
 pub struct SatPerVByte(Amount);
 
 impl SatPerVByte {

--- a/src/chain/bitcoin/timelock.rs
+++ b/src/chain/bitcoin/timelock.rs
@@ -14,7 +14,8 @@ impl FromStr for CSVTimelock {
     }
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Clone, Debug, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Clone, Debug, Copy, Display)]
+#[display("OP_CSV: {0}")]
 pub struct CSVTimelock(u32);
 
 impl CSVTimelock {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -57,6 +57,11 @@ impl Error {
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct TaggedElement<T, E>
 where
     T: Eq,
@@ -119,6 +124,11 @@ where
 
 #[derive(Debug, Clone, Copy, Display)]
 #[display(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub enum ArbitratingKeyId {
     Fund,
     Buy,
@@ -130,6 +140,11 @@ pub enum ArbitratingKeyId {
 
 #[derive(Debug, Clone, Copy, Display)]
 #[display(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub enum AccordantKeyId {
     Spend,
     Extra(u16),
@@ -137,6 +152,11 @@ pub enum AccordantKeyId {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display)]
 #[display(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct SharedKeyId(u16);
 
 impl SharedKeyId {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,7 +1,7 @@
 //! Cryptographic types and primitives supported in Farcaster
 
 use std::error;
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::io;
 
 use thiserror::Error;
@@ -82,6 +82,16 @@ where
     }
 }
 
+impl<T, E> fmt::Display for TaggedElement<T, E>
+where
+    T: Eq + fmt::Display,
+    E: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "<{}: {}>", self.tag, self.elem)
+    }
+}
+
 impl<T, E> Encodable for TaggedElement<T, E>
 where
     T: Eq + Encodable,
@@ -107,7 +117,8 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Display)]
+#[display(Debug)]
 pub enum ArbitratingKeyId {
     Fund,
     Buy,
@@ -117,13 +128,15 @@ pub enum ArbitratingKeyId {
     Extra(u16),
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Display)]
+#[display(Debug)]
 pub enum AccordantKeyId {
     Spend,
     Extra(u16),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Display)]
+#[display(Debug)]
 pub struct SharedKeyId(u16);
 
 impl SharedKeyId {
@@ -157,7 +170,7 @@ pub trait Keys {
     type PrivateKey;
 
     /// Public key type given the blockchain and the crypto engine.
-    type PublicKey: Clone + PartialEq + Debug + CanonicalBytes;
+    type PublicKey: Clone + PartialEq + Debug + fmt::Display + CanonicalBytes;
 
     fn extra_keys() -> Vec<u16>;
 }
@@ -175,7 +188,7 @@ pub trait SharedPrivateKeys {
 /// parameters that must go through the commit/reveal scheme at the beginning of the protocol.
 pub trait Commitment {
     /// Commitment type used in the commit/reveal scheme during swap parameters setup.
-    type Commitment: Clone + PartialEq + Eq + Debug + CanonicalBytes;
+    type Commitment: Clone + PartialEq + Eq + Debug + fmt::Display + CanonicalBytes;
 }
 
 /// This trait is required for arbitrating blockchains for defining the types of messages,
@@ -187,11 +200,11 @@ pub trait Signatures {
     type Message: Clone + Debug;
 
     /// Defines the signature format for the arbitrating blockchain.
-    type Signature: Clone + Debug + CanonicalBytes;
+    type Signature: Clone + Debug + fmt::Display + CanonicalBytes;
 
     /// Defines the adaptor signature format for the arbitrating blockchain. Adaptor signature may
     /// have a different format from the signature depending on the cryptographic primitives used.
-    type AdaptorSignature: Clone + Debug + CanonicalBytes;
+    type AdaptorSignature: Clone + Debug + fmt::Display + CanonicalBytes;
 }
 
 pub trait Wallet<ArPublicKey, AcPublicKey, ArSharedKey, AcSharedKey, Proof>:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@
 #![deny(unused_mut)]
 //#![deny(missing_docs)]
 
+#[macro_use]
+extern crate amplify;
+
 use thiserror::Error;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
 //! Farcaster Core library
+//!
+//! ## `serde` support
+//!
+//! The `serde` feature is disable by default.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 // Coding conventions
@@ -10,6 +14,10 @@
 
 #[macro_use]
 extern crate amplify;
+
+#[cfg(feature = "serde")]
+#[macro_use]
+extern crate serde_crate as serde;
 
 use thiserror::Error;
 

--- a/src/negotiation.rs
+++ b/src/negotiation.rs
@@ -16,7 +16,8 @@ pub const OFFER_MAGIC_BYTES: &[u8; 6] = b"FCSWAP";
 
 /// A public offer version containing the version and the activated features if
 /// any.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Display)]
+#[display("v{0}")]
 pub struct Version(u16);
 
 impl Version {

--- a/src/negotiation.rs
+++ b/src/negotiation.rs
@@ -18,6 +18,11 @@ pub const OFFER_MAGIC_BYTES: &[u8; 6] = b"FCSWAP";
 /// any.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Display)]
 #[display("v{0}")]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct Version(u16);
 
 impl Version {

--- a/src/protocol_message.rs
+++ b/src/protocol_message.rs
@@ -53,7 +53,8 @@ fn verify_vec_of_commitments<T: Eq, K: CanonicalBytes, C: Clone + Eq>(
 
 /// `commit_alice_session_params` forces Alice to commit to the result of her cryptographic setup
 /// before receiving Bob's setup. This is done to remove adaptive behavior.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Display)]
+#[display(Debug)]
 pub struct CommitAliceParameters<Ctx: Swap> {
     /// The swap identifier related to this message
     pub swap_id: SwapId,
@@ -188,7 +189,8 @@ where
 
 /// `commit_bob_session_params` forces Bob to commit to the result of his cryptographic setup
 /// before receiving Alice's setup. This is done to remove adaptive behavior.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Display)]
+#[display(Debug)]
 pub struct CommitBobParameters<Ctx: Swap> {
     /// The swap identifier related to this message
     pub swap_id: SwapId,
@@ -320,7 +322,8 @@ where
 
 /// `reveal_alice_session_params` reveals the parameters commited by the
 /// `commit_alice_session_params` message.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Display)]
+#[display(Debug)]
 pub struct RevealAliceParameters<Ctx: Swap> {
     /// The swap identifier related to this message
     pub swap_id: SwapId,
@@ -440,7 +443,8 @@ where
 
 /// `reveal_bob_session_params` reveals the parameters commited by the `commit_bob_session_params`
 /// message.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Display)]
+#[display(Debug)]
 pub struct RevealBobParameters<Ctx: Swap> {
     /// The swap identifier related to this message
     pub swap_id: SwapId,
@@ -553,7 +557,8 @@ where
 
 /// `core_arbitrating_setup` sends the `lock (b)`, `cancel (d)` and `refund (e)` arbritrating
 /// transactions from Bob to Alice, as well as Bob's signature for the `cancel (d)` transaction.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Display)]
+#[display(Debug)]
 pub struct CoreArbitratingSetup<Ctx: Swap> {
     /// The swap identifier related to this message
     pub swap_id: SwapId,
@@ -641,7 +646,8 @@ where
 /// `refund_procedure_signatures` is intended to transmit Alice's signature for the `cancel (d)`
 /// transaction and Alice's adaptor signature for the `refund (e)` transaction. Uppon reception Bob
 /// must validate the signatures.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Display)]
+#[display(Debug)]
 pub struct RefundProcedureSignatures<Ctx: Swap> {
     /// The swap identifier related to this message
     pub swap_id: SwapId,
@@ -719,7 +725,8 @@ where
 /// `buy_procedure_signature`is intended to transmit Bob's adaptor signature for the `buy (c)`
 /// transaction and the transaction itself. Uppon reception Alice must validate the transaction and
 /// the adaptor signature.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Display)]
+#[display(Debug)]
 pub struct BuyProcedureSignature<Ctx: Swap> {
     /// The swap identifier related to this message
     pub swap_id: SwapId,
@@ -785,7 +792,8 @@ where
 
 /// `abort` is an `OPTIONAL` courtesy message from either swap partner to inform the counterparty
 /// that they have aborted the swap with an `OPTIONAL` message body to provide the reason.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Display)]
+#[display(Debug)]
 pub struct Abort {
     /// The swap identifier related to this message
     pub swap_id: SwapId,

--- a/src/role.rs
+++ b/src/role.rs
@@ -154,6 +154,7 @@ impl ToString for SwapRole {
 
 /// Alice, the swap role, is the role starting with accordant blockchain assets and exchange them
 /// for arbitrating blockchain assets.
+#[derive(Debug, Clone)]
 pub struct Alice<Ctx: Swap> {
     /// An arbitrating address where, if successfully executed, the funds exchanged will be sent to
     pub destination_address: <Ctx::Ar as Address>::Address,
@@ -734,6 +735,7 @@ where
 
 /// Bob, the swap role, is the role starting with arbitrating blockchain assets and exchange them
 /// for accordant blockchain assets.
+#[derive(Debug, Clone)]
 pub struct Bob<Ctx: Swap> {
     /// An arbitrating address where, if unsuccessfully executed, the funds exchanged will be sent
     /// back to

--- a/src/role.rs
+++ b/src/role.rs
@@ -27,6 +27,11 @@ use crate::Error;
 /// Defines the possible roles during the negotiation phase. Any negotiation role can transition
 /// into any swap role when negotiation is done.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub enum TradeRole {
     /// The maker role create the public offer during the negotiation phase and waits for incoming
     /// connections.
@@ -91,6 +96,11 @@ impl ToString for TradeRole {
 /// Defines the possible roles during the swap phase. When negotitation is done negotitation role
 /// will transition into swap role.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub enum SwapRole {
     /// Alice, the swap role, is the role starting with accordant blockchain assets and exchange
     /// them for arbitrating blockchain assets.

--- a/src/script.rs
+++ b/src/script.rs
@@ -4,7 +4,8 @@ use crate::blockchain::Timelock;
 use crate::crypto::Keys;
 
 /// Represent a public key-pair, one key per swap role in the system.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
+#[display("Alice: {alice}, Bob: {bob}")]
 pub struct DoubleKeys<T>
 where
     T: Keys,
@@ -24,7 +25,8 @@ where
 }
 
 /// Define the path in a script with its associated data.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Display)]
+#[display(Debug)]
 pub enum ScriptPath {
     /// The success path in the script.
     Success,
@@ -34,7 +36,8 @@ pub enum ScriptPath {
 
 /// The data used to create a lock and remove the double spending problem and create a mutually
 /// agreed refundable path.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
+#[display("Timelock: {timelock}, Success: <{success}>, Failure: <{failure}>")]
 pub struct DataLock<T>
 where
     T: Timelock + Keys,
@@ -46,7 +49,8 @@ where
 
 /// The data used to create a lock and remove the double spending problem and create an unilateral
 /// punishment mechanism.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
+#[display("Timelock: {timelock}, Success: <{success}>, Failure: {failure}")]
 pub struct DataPunishableLock<T>
 where
     T: Timelock + Keys,

--- a/src/script.rs
+++ b/src/script.rs
@@ -6,6 +6,11 @@ use crate::crypto::Keys;
 /// Represent a public key-pair, one key per swap role in the system.
 #[derive(Debug, Clone, Display)]
 #[display("Alice: {alice}, Bob: {bob}")]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct DoubleKeys<T>
 where
     T: Keys,
@@ -27,6 +32,11 @@ where
 /// Define the path in a script with its associated data.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Display)]
 #[display(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub enum ScriptPath {
     /// The success path in the script.
     Success,

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -8,11 +8,14 @@ use crate::crypto::Commitment;
 use crate::role::{Accordant, Arbitrating};
 
 use lightning_encoding::strategies::AsStrict;
-use serde::{Deserialize, Serialize};
 
 fixed_hash::construct_fixed_hash!(
     /// A unique swap identifier represented as an 32 bytes hash.
-    #[derive(Serialize, Deserialize)]
+    #[cfg_attr(
+        feature = "serde",
+        derive(Serialize, Deserialize),
+        serde(crate = "serde_crate"),
+    )]
     pub struct SwapId(32);
 );
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -98,7 +98,8 @@ where
 }
 
 /// Defines the transaction IDs for serialization and network communication.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display)]
+#[display(Debug)]
 pub enum TxId {
     /// Represents the first transaction created outside of the system by an external wallet to
     /// fund the swap on the arbitrating blockchain.


### PR DESCRIPTION
Fix #88 

Implement `fmt::Display` for major structures in the lib.

This introduces display and serde on the structure where it is easily possible to do so. More refactor must be done to extend it's support, or enforce serde everywhere for having Offer, PublicOffer and other messages as currently designed.