### PR TITLE
Modify segwit0 and extract witness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
     - uses: Swatinem/rust-cache@v1.3.0
 
-    - run: cargo test --verbose
+    - run: cargo test --features serde --verbose
 
   rpc-test:
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ bitcoincore-rpc = "0.13.0"
 rand_core = { version = "^0.6.3", features = ["getrandom"] }
 secp256k1 = { version = "0.20.1", features = ["rand-std"] }
 lazy_static = "1.4.0"
+serde_yaml = "0.8"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/contrib/run-rpc-tests.sh
+++ b/contrib/run-rpc-tests.sh
@@ -2,30 +2,18 @@
 
 cd ..
 
-docker volume create --name bitcoind-data
+ID=$(docker run --rm -d -p 18443:18443 coblox/bitcoin-core\
+    -regtest\
+    -server\
+    -fallbackfee=0.00001\
+    -rpcbind=0.0.0.0\
+    -rpcallowip=0.0.0.0/0\
+    -rpcuser=test\
+    -rpcpassword=cEl2o3tHHgzYeuu3CiiZ2FjdgSiw9wNeMFzoNbFmx9k=)
 
-ID=$(docker create -p 18443:18443\
-    --name bitcoind\
-    --env NETWORK=regtest\
-    --env FALLBACKFEE=0.00001\
-    --env RPC_PORT=18443\
-    -v bitcoind-data:/data\
-    ghcr.io/farcaster-project/containers/bitcoin-core:latest)
-
-docker start $ID
-
-docker run --rm\
-    --link bitcoind\
-    --volumes-from bitcoind\
-    -v "$PWD":/usr/src/myapp\
-    -w /usr/src/myapp\
-    --env RPC_HOST=bitcoind\
-    rust:1.54.0\
-    cargo test --test transactions --features rpc -- --test-threads=1
+export CI=false RPC_USER=test RPC_PASS=cEl2o3tHHgzYeuu3CiiZ2FjdgSiw9wNeMFzoNbFmx9k=
+cargo test --test transactions --features rpc -- --test-threads=1
 
 docker kill $ID
-docker container rm $ID
-
-docker volume rm bitcoind-data
 
 cd -

--- a/src/bitcoin/segwitv0/buy.rs
+++ b/src/bitcoin/segwitv0/buy.rs
@@ -1,17 +1,17 @@
 use std::marker::PhantomData;
 
-use bitcoin::blockdata::script::Instruction;
 use bitcoin::blockdata::transaction::{SigHashType, TxIn, TxOut};
-use bitcoin::util::key::PublicKey;
 use bitcoin::util::psbt::PartiallySignedTransaction;
 use bitcoin::Address;
 
+use crate::role::SwapRole;
 use crate::script;
 use crate::transaction::{Buyable, Error as FError, Lockable};
 
-use crate::bitcoin::segwitv0::SegwitV0;
+use crate::bitcoin::segwitv0::{CoopLock, SegwitV0};
 use crate::bitcoin::transaction::{Error, MetadataOutput, SubTransaction, Tx};
 use crate::bitcoin::Bitcoin;
+use bitcoin::secp256k1::Signature;
 
 #[derive(Debug)]
 pub struct Buy;
@@ -23,45 +23,21 @@ impl SubTransaction for Buy {
             .clone()
             .ok_or(FError::MissingWitness)?;
 
-        let mut keys = script.instructions().skip(2).take(2);
+        let swaplock = CoopLock::from_script(&script)?;
 
-        psbt.inputs[0].final_script_witness = Some(vec![
-            vec![], // 0 for multisig
-            psbt.inputs[0]
-                .partial_sigs
-                .get(
-                    &PublicKey::from_slice(
-                        keys.next()
-                            .ok_or(FError::MissingPublicKey)?
-                            .map(|i| match i {
-                                Instruction::PushBytes(b) => Ok(b),
-                                _ => Err(FError::MissingPublicKey),
-                            })
-                            .map_err(Error::from)??,
-                    )
-                    .map_err(|_| FError::MissingPublicKey)?,
-                )
-                .ok_or(FError::MissingSignature)?
-                .clone(),
-            psbt.inputs[0]
-                .partial_sigs
-                .get(
-                    &PublicKey::from_slice(
-                        keys.next()
-                            .ok_or(FError::MissingPublicKey)?
-                            .map(|i| match i {
-                                Instruction::PushBytes(b) => Ok(b),
-                                _ => Err(FError::MissingPublicKey),
-                            })
-                            .map_err(Error::from)??,
-                    )
-                    .map_err(|_| FError::MissingPublicKey)?,
-                )
-                .ok_or(FError::MissingSignature)?
-                .clone(),
-            vec![1],             // OP_TRUE
-            script.into_bytes(), // swaplock script
-        ]);
+        let alice_sig = psbt.inputs[0]
+            .partial_sigs
+            .get(swaplock.get_pubkey(SwapRole::Alice))
+            .ok_or(FError::MissingSignature)?
+            .clone();
+
+        let bob_sig = psbt.inputs[0]
+            .partial_sigs
+            .get(swaplock.get_pubkey(SwapRole::Bob))
+            .ok_or(FError::MissingSignature)?
+            .clone();
+
+        psbt.inputs[0].final_script_witness = Some(vec![bob_sig, alice_sig, script.into_bytes()]);
 
         Ok(())
     }
@@ -75,12 +51,12 @@ impl Buyable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Buy> {
     ) -> Result<Self, FError> {
         let output_metadata = prev.get_consumable_output()?;
 
-        let unsigned_tx = bitcoin::blockdata::transaction::Transaction {
+        let unsigned_tx = bitcoin::Transaction {
             version: 2,
             lock_time: 0,
             input: vec![TxIn {
                 previous_output: output_metadata.out_point,
-                script_sig: bitcoin::blockdata::script::Script::default(),
+                script_sig: bitcoin::Script::default(),
                 sequence: 0,
                 witness: vec![],
             }],
@@ -104,12 +80,37 @@ impl Buyable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Buy> {
         })
     }
 
-    fn verify_template(
-        &self,
-        _lock: script::DataLock<Bitcoin<SegwitV0>>,
-        _destination_target: Address,
-    ) -> Result<(), FError> {
-        // FIXME
+    fn verify_template(&self, destination_target: Address) -> Result<(), FError> {
+        (self.psbt.global.unsigned_tx.version == 2)
+            .then(|| 0)
+            .ok_or(FError::WrongTemplate("Tx version is not 2"))?;
+        (self.psbt.global.unsigned_tx.lock_time == 0)
+            .then(|| 0)
+            .ok_or(FError::WrongTemplate("LockTime is not set to 0"))?;
+        (self.psbt.global.unsigned_tx.input.len() == 1)
+            .then(|| 0)
+            .ok_or(FError::WrongTemplate("Number of inputs is not 1"))?;
+        (self.psbt.global.unsigned_tx.output.len() == 1)
+            .then(|| 0)
+            .ok_or(FError::WrongTemplate("Number of outputs is not 1"))?;
+
+        let txin = &self.psbt.global.unsigned_tx.input[0];
+        (txin.sequence == 0)
+            .then(|| 0)
+            .ok_or(FError::WrongTemplate("Sequence is not set to 0"))?;
+
+        let txout = &self.psbt.global.unsigned_tx.output[0];
+        let script_pubkey = destination_target.script_pubkey();
+        (txout.script_pubkey == script_pubkey)
+            .then(|| 0)
+            .ok_or(FError::WrongTemplate("Script pubkey does not match"))?;
+
         Ok(())
+    }
+
+    fn extract_witness(tx: bitcoin::Transaction) -> Signature {
+        let TxIn { witness, .. } = &tx.input[0];
+        Signature::from_compact(witness[1].as_ref())
+            .expect("Validated transaction on-chain, signature and witness position is correct.")
     }
 }

--- a/src/bitcoin/timelock.rs
+++ b/src/bitcoin/timelock.rs
@@ -31,6 +31,11 @@ impl CSVTimelock {
     pub fn as_u32(&self) -> u32 {
         self.0
     }
+
+    /// Return the value of nSequence that disable `CHECK_SEQUENCE_VERIFY`.
+    pub fn disable() -> u32 {
+        (1 << 31) as u32
+    }
 }
 
 impl CanonicalBytes for CSVTimelock {

--- a/src/role.rs
+++ b/src/role.rs
@@ -174,12 +174,11 @@ pub struct Alice<Ctx: Swap> {
     pub fee_politic: FeePriority,
 }
 
-struct ValidatedCoreTransactions<Ctx: Swap> {
+struct ValidatedCoreTransactions<'a, Ctx: Swap> {
     lock: <Ctx::Ar as Transactions>::Lock,
     cancel: <Ctx::Ar as Transactions>::Cancel,
     refund: <Ctx::Ar as Transactions>::Refund,
-    data_lock: DataLock<Ctx::Ar>,
-    punish_lock: DataPunishableLock<Ctx::Ar>,
+    punish_lock: DataPunishableLock<'a, Ctx::Ar>,
 }
 
 impl<Ctx> Alice<Ctx>
@@ -441,9 +440,8 @@ where
         adaptor_buy: &SignedAdaptorBuy<Ctx::Ar>,
     ) -> Res<()> {
         // Verifies the core arbitrating transactions.
-        let ValidatedCoreTransactions {
-            lock, data_lock, ..
-        } = self.validate_core(alice_parameters, bob_parameters, core, public_offer)?;
+        let ValidatedCoreTransactions { lock, .. } =
+            self.validate_core(alice_parameters, bob_parameters, core, public_offer)?;
 
         let fee_strategy = &public_offer.offer.fee_strategy;
 
@@ -455,7 +453,7 @@ where
         let buy = <<Ctx::Ar as Transactions>::Buy>::from_partial(partial_buy);
 
         buy.is_build_on_top_of(&lock)?;
-        buy.verify_template(data_lock, self.destination_address.clone())?;
+        buy.verify_template(self.destination_address.clone())?;
         <Ctx::Ar as Fee>::validate_fee(buy.as_partial(), fee_strategy)?;
 
         // Verify the adaptor buy witness
@@ -522,9 +520,8 @@ where
         adaptor_buy: &SignedAdaptorBuy<Ctx::Ar>,
     ) -> Res<FullySignedBuy<Ctx::Ar>> {
         // Verifies the core arbitrating transactions.
-        let ValidatedCoreTransactions {
-            lock, data_lock, ..
-        } = self.validate_core(alice_parameters, bob_parameters, core, public_offer)?;
+        let ValidatedCoreTransactions { lock, .. } =
+            self.validate_core(alice_parameters, bob_parameters, core, public_offer)?;
 
         let fee_strategy = &public_offer.offer.fee_strategy;
 
@@ -536,7 +533,7 @@ where
         let buy = <<Ctx::Ar as Transactions>::Buy>::from_partial(partial_buy);
 
         buy.is_build_on_top_of(&lock)?;
-        buy.verify_template(data_lock, self.destination_address.clone())?;
+        buy.verify_template(self.destination_address.clone())?;
         <Ctx::Ar as Fee>::validate_fee(buy.as_partial(), fee_strategy)?;
 
         // Generate the witness message to sign and sign with the buy key.
@@ -643,13 +640,13 @@ where
     //  * the target amount from the offer is correct (for the lock transaction)
     //  * the fee strategy validation passes
     //
-    fn validate_core(
+    fn validate_core<'a>(
         &self,
-        alice_parameters: &AliceParameters<Ctx>,
-        bob_parameters: &BobParameters<Ctx>,
+        alice_parameters: &'a AliceParameters<Ctx>,
+        bob_parameters: &'a BobParameters<Ctx>,
         core: &CoreArbitratingTransactions<Ctx::Ar>,
         public_offer: &PublicOffer<Ctx>,
-    ) -> Res<ValidatedCoreTransactions<Ctx>> {
+    ) -> Res<ValidatedCoreTransactions<'a, Ctx>> {
         // Extract the partial transaction from the core arbitrating bundle, this operation should
         // not error if the bundle is well formed.
         let partial_lock = core.lock.clone();
@@ -660,11 +657,10 @@ where
         // Get the four keys, Alice and Bob for Buy and Cancel. The keys are needed, along with the
         // timelock for the cancel, to create the cancelable on-chain contract on the arbitrating
         // blockchain.
-        // FIXME change dataLock to take refs
-        let alice_buy = alice_parameters.buy.clone();
-        let bob_buy = bob_parameters.buy.clone();
-        let alice_cancel = alice_parameters.cancel.clone();
-        let bob_cancel = bob_parameters.cancel.clone();
+        let alice_buy = &alice_parameters.buy;
+        let bob_buy = &bob_parameters.buy;
+        let alice_cancel = &alice_parameters.cancel;
+        let bob_cancel = &bob_parameters.cancel;
 
         // Create the data structure that represents an on-chain cancelable contract for the
         // arbitrating blockchain.
@@ -687,10 +683,9 @@ where
         // Get the three keys, Alice and Bob for refund and Alice's punish key. The keys are
         // needed, along with the timelock for the punish, to create the punishable on-chain
         // contract on the arbitrating blockchain.
-        // FIXME change dataLock to take refs
-        let alice_refund = alice_parameters.refund.clone();
-        let bob_refund = bob_parameters.refund.clone();
-        let alice_punish = alice_parameters.punish.clone();
+        let alice_refund = &alice_parameters.refund;
+        let bob_refund = &bob_parameters.refund;
+        let alice_punish = &alice_parameters.punish;
 
         // Create the data structure that represents an on-chain punishable contract for the
         // arbitrating blockchain.
@@ -721,7 +716,7 @@ where
         // Check that the refund transaction is build on top of the cancel transaction.
         refund.is_build_on_top_of(&cancel)?;
         let refund_address = bob_parameters.refund_address.clone();
-        refund.verify_template(punish_lock.clone(), refund_address)?;
+        refund.verify_template(refund_address)?;
         // Validate the fee strategy
         <Ctx::Ar as Fee>::validate_fee(refund.as_partial(), fee_strategy)?;
 
@@ -729,7 +724,6 @@ where
             lock,
             cancel,
             refund,
-            data_lock,
             punish_lock,
         })
     }
@@ -893,10 +887,10 @@ impl<Ctx: Swap> Bob<Ctx> {
         // Get the four keys, Alice and Bob for Buy and Cancel. The keys are needed, along with the
         // timelock for the cancel, to create the cancelable on-chain contract on the arbitrating
         // blockchain.
-        let alice_buy = alice_parameters.buy.clone();
-        let bob_buy = bob_parameters.buy.clone();
-        let alice_cancel = alice_parameters.cancel.clone();
-        let bob_cancel = bob_parameters.cancel.clone();
+        let alice_buy = &alice_parameters.buy;
+        let bob_buy = &bob_parameters.buy;
+        let alice_cancel = &alice_parameters.cancel;
+        let bob_cancel = &bob_parameters.cancel;
 
         // Create the data structure that represents an on-chain cancelable contract for the
         // arbitrating blockchain.
@@ -924,9 +918,9 @@ impl<Ctx: Swap> Bob<Ctx> {
         // Get the three keys, Alice and Bob for refund and Alice's punish key. The keys are
         // needed, along with the timelock for the punish, to create the punishable on-chain
         // contract on the arbitrating blockchain.
-        let alice_refund = alice_parameters.refund.clone();
-        let bob_refund = bob_parameters.refund.clone();
-        let alice_punish = alice_parameters.punish.clone();
+        let alice_refund = &alice_parameters.refund;
+        let bob_refund = &bob_parameters.refund;
+        let alice_punish = &alice_parameters.punish;
 
         // Create the data structure that represents an on-chain punishable contract for the
         // arbitrating blockchain.
@@ -951,7 +945,7 @@ impl<Ctx: Swap> Bob<Ctx> {
         let mut refund = <<Ctx::Ar as Transactions>::Refund as Refundable<
             Ctx::Ar,
             <Ctx::Ar as Transactions>::Metadata,
-        >>::initialize(&cancel, punish_lock, self.refund_address.clone())?;
+        >>::initialize(&cancel, self.refund_address.clone())?;
 
         // Set the fees according to the strategy in the offer and the local politic.
         <Ctx::Ar as Fee>::set_fee(refund.as_partial_mut(), fee_strategy, self.fee_politic)?;
@@ -1133,10 +1127,10 @@ impl<Ctx: Swap> Bob<Ctx> {
         // Get the four keys, Alice and Bob for Buy and Cancel. The keys are needed, along with the
         // timelock for the cancel, to create the cancelable on-chain contract on the arbitrating
         // blockchain.
-        let alice_buy = alice_parameters.buy.clone();
-        let bob_buy = bob_parameters.buy.clone();
-        let alice_cancel = alice_parameters.cancel.clone();
-        let bob_cancel = bob_parameters.cancel.clone();
+        let alice_buy = &alice_parameters.buy;
+        let bob_buy = &bob_parameters.buy;
+        let alice_cancel = &alice_parameters.cancel;
+        let bob_cancel = &bob_parameters.cancel;
 
         // Create the data structure that represents an on-chain cancelable contract for the
         // arbitrating blockchain.

--- a/src/role.rs
+++ b/src/role.rs
@@ -625,8 +625,23 @@ where
         })
     }
 
-    pub fn recover_accordant_assets(&self) -> Res<()> {
-        todo!()
+    // TODO: transform into other private key type
+    pub fn recover_accordant_assets(
+        &self,
+        wallet: &mut impl Sign<
+            <Ctx::Ar as Keys>::PublicKey,
+            <Ctx::Ar as Keys>::PrivateKey,
+            <Ctx::Ar as Signatures>::Message,
+            <Ctx::Ar as Signatures>::Signature,
+            <Ctx::Ar as Signatures>::AdaptorSignature,
+        >,
+        bob_parameters: &BobParameters<Ctx>,
+        adaptor_refund: SignedAdaptorRefund<Ctx::Ar>,
+        refund_tx: <Ctx::Ar as Onchain>::Transaction,
+    ) -> <Ctx::Ar as Keys>::PrivateKey {
+        let adaptor_key = &bob_parameters.adaptor;
+        let signature = <<Ctx::Ar as Transactions>::Refund>::extract_witness(refund_tx);
+        wallet.recover_key(adaptor_key, signature, adaptor_refund.refund_adaptor_sig)
     }
 
     // Internal method to parse and validate the core arbitratring transactions received by Alice
@@ -1277,8 +1292,22 @@ impl<Ctx: Swap> Bob<Ctx> {
         })
     }
 
-    pub fn recover_accordant_assets(&self) -> Res<()> {
-        todo!()
+    pub fn recover_accordant_assets(
+        &self,
+        wallet: &mut impl Sign<
+            <Ctx::Ar as Keys>::PublicKey,
+            <Ctx::Ar as Keys>::PrivateKey,
+            <Ctx::Ar as Signatures>::Message,
+            <Ctx::Ar as Signatures>::Signature,
+            <Ctx::Ar as Signatures>::AdaptorSignature,
+        >,
+        alice_parameters: &AliceParameters<Ctx>,
+        adaptor_buy: SignedAdaptorBuy<Ctx::Ar>,
+        buy_tx: <Ctx::Ar as Onchain>::Transaction,
+    ) -> <Ctx::Ar as Keys>::PrivateKey {
+        let adaptor_key = &alice_parameters.adaptor;
+        let signature = <<Ctx::Ar as Transactions>::Buy>::extract_witness(buy_tx);
+        wallet.recover_key(adaptor_key, signature, adaptor_buy.buy_adaptor_sig)
     }
 }
 

--- a/src/script.rs
+++ b/src/script.rs
@@ -13,22 +13,22 @@ use crate::crypto::Keys;
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-pub struct DoubleKeys<T>
+pub struct DoubleKeys<'a, T>
 where
     T: Keys,
 {
     /// Public key associated to Alice swap role.
-    pub alice: T::PublicKey,
+    pub alice: &'a T::PublicKey,
     /// Public key associated to Bob swap role.
-    pub bob: T::PublicKey,
+    pub bob: &'a T::PublicKey,
 }
 
-impl<T> DoubleKeys<T>
+impl<'a, T> DoubleKeys<'a, T>
 where
     T: Keys,
 {
     /// Store public keys for swap participant.
-    pub fn new(alice: T::PublicKey, bob: T::PublicKey) -> Self {
+    pub fn new(alice: &'a T::PublicKey, bob: &'a T::PublicKey) -> Self {
         Self { alice, bob }
     }
 }
@@ -55,13 +55,13 @@ pub enum ScriptPath {
 /// [`Buyable`]: crate::transaction::Buyable
 #[derive(Debug, Clone, Display)]
 #[display("Timelock: {timelock}, Success: <{success}>, Failure: <{failure}>")]
-pub struct DataLock<T>
+pub struct DataLock<'a, T>
 where
     T: Timelock + Keys,
 {
     pub timelock: T::Timelock,
-    pub success: DoubleKeys<T>,
-    pub failure: DoubleKeys<T>,
+    pub success: DoubleKeys<'a, T>,
+    pub failure: DoubleKeys<'a, T>,
 }
 
 /// Store Alice and Bob public keys for the sucessful and failure paths and the timelock value used
@@ -71,11 +71,11 @@ where
 /// [`Cancelable`]: crate::transaction::Cancelable
 #[derive(Debug, Clone, Display)]
 #[display("Timelock: {timelock}, Success: <{success}>, Failure: {failure}")]
-pub struct DataPunishableLock<T>
+pub struct DataPunishableLock<'a, T>
 where
     T: Timelock + Keys,
 {
     pub timelock: T::Timelock,
-    pub success: DoubleKeys<T>,
-    pub failure: T::PublicKey,
+    pub success: DoubleKeys<'a, T>,
+    pub failure: &'a T::PublicKey,
 }

--- a/src/script.rs
+++ b/src/script.rs
@@ -1,5 +1,8 @@
 //! Data structures used in scripts to create the arbitration engine on a blockchain.
 
+#[cfg(feature = "serde")]
+use serde::Serialize;
+
 use crate::blockchain::Timelock;
 use crate::crypto::Keys;
 
@@ -10,8 +13,11 @@ use crate::crypto::Keys;
 #[display("Alice: {alice}, Bob: {bob}")]
 #[cfg_attr(
     feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(crate = "serde_crate")
+    derive(Serialize),
+    serde(
+        crate = "serde_crate",
+        bound(serialize = "&'a T::PublicKey: Serialize",)
+    )
 )]
 pub struct DoubleKeys<'a, T>
 where
@@ -78,4 +84,28 @@ where
     pub timelock: T::Timelock,
     pub success: DoubleKeys<'a, T>,
     pub failure: &'a T::PublicKey,
+}
+
+#[cfg(test)]
+#[cfg(feature = "serde")]
+mod tests {
+    use super::*;
+    use crate::bitcoin::BitcoinSegwitV0;
+
+    #[test]
+    fn serde_serialize_double_keys() {
+        let public_key = bitcoin::secp256k1::PublicKey::from_slice(&[
+            0x02, 0xc6, 0x6e, 0x7d, 0x89, 0x66, 0xb5, 0xc5, 0x55, 0xaf, 0x58, 0x05, 0x98, 0x9d,
+            0xa9, 0xfb, 0xf8, 0xdb, 0x95, 0xe1, 0x56, 0x31, 0xce, 0x35, 0x8c, 0x3a, 0x17, 0x10,
+            0xc9, 0x62, 0x67, 0x90, 0x63,
+        ])
+        .expect("public keys must be 33 or 65 bytes, serialized according to SEC 2");
+        let double_key = DoubleKeys::<'_, BitcoinSegwitV0>::new(&public_key, &public_key);
+        let s = serde_yaml::to_string(&double_key).unwrap();
+        let yml = r#"---
+alice: 02c66e7d8966b5c555af5805989da9fbf8db95e15631ce358c3a1710c962679063
+bob: 02c66e7d8966b5c555af5805989da9fbf8db95e15631ce358c3a1710c962679063
+"#;
+        assert_eq!(yml, s);
+    }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -40,8 +40,8 @@ pub enum Error {
     #[error("Not enough assets to create the transaction")]
     NotEnoughAssets,
     /// Wrong transaction template.
-    #[error("Wrong transaction template")]
-    WrongTemplate,
+    #[error("Wrong transaction template: {0}")]
+    WrongTemplate(&'static str),
     /// The transaction chain validation failed
     #[error("The transaction chain validation failed")]
     InvalidTransactionChain,
@@ -340,11 +340,10 @@ where
 
     /// Verifies that the transaction is compliant with the protocol requirements and implements
     /// the correct conditions of the [`DataLock`] and the destination address.
-    fn verify_template(
-        &self,
-        lock: DataLock<T>,
-        destination_target: T::Address,
-    ) -> Result<(), Error>;
+    fn verify_template(&self, destination_target: T::Address) -> Result<(), Error>;
+
+    /// Extract the valuable witness from a transaction.
+    fn extract_witness(tx: T::Transaction) -> T::Signature;
 
     /// Return the Farcaster transaction identifier.
     fn get_id(&self) -> TxLabel {
@@ -405,19 +404,11 @@ where
     ///
     /// This correspond to the "creator" and initial "updater" roles in BIP 174. Creates a new
     /// transaction and fill the inputs and outputs data.
-    fn initialize(
-        prev: &impl Cancelable<T, O>,
-        punish_lock: DataPunishableLock<T>,
-        refund_target: T::Address,
-    ) -> Result<Self, Error>;
+    fn initialize(prev: &impl Cancelable<T, O>, refund_target: T::Address) -> Result<Self, Error>;
 
     /// Verifies that the transaction is compliant with the protocol requirements and implements
     /// the correct conditions of the [`DataPunishableLock`] and the refund address.
-    fn verify_template(
-        &self,
-        punish_lock: DataPunishableLock<T>,
-        refund_target: T::Address,
-    ) -> Result<(), Error>;
+    fn verify_template(&self, refund_target: T::Address) -> Result<(), Error>;
 
     /// Return the Farcaster transaction identifier.
     fn get_id(&self) -> TxLabel {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -410,6 +410,9 @@ where
     /// the correct conditions of the [`DataPunishableLock`] and the refund address.
     fn verify_template(&self, refund_target: T::Address) -> Result<(), Error>;
 
+    /// Extract the valuable witness from a transaction.
+    fn extract_witness(tx: T::Transaction) -> T::Signature;
+
     /// Return the Farcaster transaction identifier.
     fn get_id(&self) -> TxLabel {
         TxLabel::Refund

--- a/tests/rpc/mod.rs
+++ b/tests/rpc/mod.rs
@@ -4,14 +4,24 @@ use std::path::PathBuf;
 
 lazy_static::lazy_static! {
     pub static ref CLIENT: Client =  {
+        let ctx = env::var("CI").unwrap_or("false".into());
         let host = env::var("RPC_HOST").unwrap_or("127.0.0.1".into());
         let port = env::var("RPC_PORT").unwrap_or("18443".into());
-        let cookie = env::var("RPC_COOKIE").unwrap_or("/data/regtest/.cookie".into());
-        let path = PathBuf::from(cookie);
-        Client::new(
-            format!("http://{}:{}", host, port),
-            Auth::CookieFile(path),
-        ).unwrap()
+        if ctx == "false" {
+            let u = env::var("RPC_USER").unwrap();
+            let p = env::var("RPC_PASS").unwrap();
+            Client::new(
+                format!("http://{}:{}", host, port),
+                Auth::UserPass(u, p),
+            ).unwrap()
+        } else {
+            let cookie = env::var("RPC_COOKIE").unwrap_or("/data/regtest/.cookie".into());
+            let path = PathBuf::from(cookie);
+            Client::new(
+                format!("http://{}:{}", host, port),
+                Auth::CookieFile(path),
+            ).unwrap()
+        }
     };
 }
 


### PR DESCRIPTION
Work in progress, modify the segwit v0 implementation and complete the tx management by extracting the witness from buy (todo for refund).

Still need a lot of tests everywhere for the transactions implementation, to be sure that the template verification is done correctly, that the witness extraction works, etc.