### PR TITLE
Update Bitcoin and Bitcoincore RPC deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,14 +49,14 @@ bincode = { version = "1.3.3", optional = true }
 curve25519-dalek = "3"
 
 # blockchain specific
-bitcoin = "0.26"
+bitcoin = "0.27"
 monero = { version = "0.14" }
 
 [dev-dependencies]
-bitcoincore-rpc = "0.13.0"
+bitcoincore-rpc = "0.14"
 rand_core = { version = "^0.6.3", features = ["getrandom"] }
-secp256k1 = { version = "0.20.1", features = ["rand-std"] }
-lazy_static = "1.4.0"
+secp256k1 = { version = "0.20", features = ["rand-std"] }
+lazy_static = "1.4"
 serde_yaml = "0.8"
 
 [package.metadata.docs.rs]

--- a/tests/rpc/mod.rs
+++ b/tests/rpc/mod.rs
@@ -11,14 +11,14 @@ lazy_static::lazy_static! {
             let u = env::var("RPC_USER").unwrap();
             let p = env::var("RPC_PASS").unwrap();
             Client::new(
-                format!("http://{}:{}", host, port),
+                format!("http://{}:{}", host, port).as_str(),
                 Auth::UserPass(u, p),
             ).unwrap()
         } else {
             let cookie = env::var("RPC_COOKIE").unwrap_or("/data/regtest/.cookie".into());
             let path = PathBuf::from(cookie);
             Client::new(
-                format!("http://{}:{}", host, port),
+                format!("http://{}:{}", host, port).as_str(),
                 Auth::CookieFile(path),
             ).unwrap()
         }


### PR DESCRIPTION
Fix RPC for new version. Rewriting some version in Cargo.toml, this
should not change how deps are managed.