### PR TITLE
bump lnp dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,12 @@ amplify = "3"
 hex = "0.4.3"
 tiny-keccak = { version = "2", features = ["keccak"] }
 fixed-hash = { version = "0.7.0", default-features = false }
-strict_encoding = "=1.2.3"
-strict_encoding_derive = "=1.0.0"
-lightning_encoding = "0.4.0-beta.1"
+strict_encoding = "=1.7.4"
+strict_encoding_derive = "=1.7.4"
+lightning_encoding = "0.5.0-beta.3"
 thiserror = "1.0.24"
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
-inet2_addr = { version = "0.4.0", default-features = false, features = ["tor", "strict_encoding"] }
+inet2_addr = { version = "0.5.0", default-features = false, features = ["tor", "strict_encoding"] }
 bitvec = { version = "0.22.3" }
 bitcoin_hashes = { version = "0.10.0" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ amplify = "3"
 hex = "0.4.3"
 tiny-keccak = { version = "2", features = ["keccak"] }
 fixed-hash = { version = "0.7.0", default-features = false }
-strict_encoding = "=1.7.4"
-strict_encoding_derive = "=1.7.4"
+strict_encoding = "1.7.4"
+strict_encoding_derive = "1.7.4"
 lightning_encoding = "0.5.0-beta.3"
 thiserror = "1.0.24"
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }


### PR DESCRIPTION
required for downstream bitcoin 0.27 bumps: https://github.com/farcaster-project/farcaster-node/pull/120