### PR TITLE
remove public keys from DLEQ proof

### DIFF
--- a/src/swap/btcxmr.rs
+++ b/src/swap/btcxmr.rs
@@ -430,8 +430,11 @@ impl ProveCrossGroupDleq<PublicKey, monero::PublicKey, DLEQProof> for KeyManager
         proof: DLEQProof,
     ) -> Result<(), crypto::Error> {
         proof.verify(
-            public_spend.point.decompress().unwrap(),
-            ecdsa_fun::fun::Point::from_bytes(encryption_key.serialize()).unwrap(),
+            public_spend
+                .point
+                .decompress()
+                .expect("Valid point to decompress"),
+            ecdsa_fun::fun::Point::from(*encryption_key),
         )
     }
 }

--- a/src/swap/btcxmr.rs
+++ b/src/swap/btcxmr.rs
@@ -429,12 +429,9 @@ impl ProveCrossGroupDleq<PublicKey, monero::PublicKey, DLEQProof> for KeyManager
         encryption_key: &PublicKey,
         proof: DLEQProof,
     ) -> Result<(), crypto::Error> {
-        if public_spend.point != proof.xG_p.compress() {
-            return Err(crypto::Error::InvalidProof);
-        }
-        if encryption_key.serialize_uncompressed() != proof.xH_p.to_bytes_uncompressed() {
-            return Err(crypto::Error::InvalidProof);
-        }
-        proof.verify()
+        proof.verify(
+            public_spend.point.decompress().unwrap(),
+            ecdsa_fun::fun::Point::from_bytes(encryption_key.serialize()).unwrap(),
+        )
     }
 }


### PR DESCRIPTION
our protocol messages are slightly too large for the frame limit (`65815` bytes vs `65535 + 18 + 16 = 65569` bytes) imposed by [rust-internet2::transport](https://github.com/internet2-org/rust-internet2/blob/master/src/transport/mod.rs#L35-L47) (i.e. [BOLT](https://github.com/lightningnetwork/lightning-rfc/blob/master/01-messaging.md#type-length-value-format)), and these pubkeys can be reconstructed from commitments anyway. This shaves off `65` bytes and thus gets us a bit closer ;)