### PR TITLE
Update shared workflows and add publish after release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ env:
 jobs:
 
   rustdoc:
+    name: Build doc
 
     runs-on: ubuntu-latest
 
@@ -31,6 +32,7 @@ jobs:
         RUSTDOCFLAGS: "--cfg docsrs"
 
   build:
+    name: Build lib
 
     strategy:
       matrix:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,4 +9,4 @@ jobs:
   create_release:
     name: Create from merged release branch
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
-    uses: farcaster-project/workflows/.github/workflows/create-release.yml@v1.0.1
+    uses: farcaster-project/workflows/.github/workflows/create-release.yml@v1.0.2

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   draft-new-release:
     name: "Draft a new release"
-    uses: farcaster-project/workflows/.github/workflows/draft-new-release.yml@v1.0.1
+    uses: farcaster-project/workflows/.github/workflows/draft-new-release.yml@v1.0.2
     with:
       version: ${{ github.event.inputs.version }}

--- a/.github/workflows/release-to-crates-io.yml
+++ b/.github/workflows/release-to-crates-io.yml
@@ -3,10 +3,14 @@ name: Release to crates.io
 on:
   release:
     types: [ created ]
+  workflow_run:
+    workflows: ["Create release"]
+    types:
+      - completed
 
 jobs:
   release:
     name: "Publish the new release to crates.io"
-    uses: farcaster-project/workflows/.github/workflows/release-to-crates-io.yml@v1.0.1
+    uses: farcaster-project/workflows/.github/workflows/release-to-crates-io.yml@v1.0.2
     secrets:
       cratesio_token: ${{ secrets.H4SH3D_CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ env:
 jobs:
 
   test:
+    name: Unit tests
     strategy:
       matrix:
         rust: [
@@ -36,6 +37,7 @@ jobs:
     - run: cargo test --features serde --verbose
 
   rpc-test:
+    name: Integration tests
     strategy:
       matrix:
         rust: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Correct publish been not triggered after release ([#165](https://github.com/farcaster-project/farcaster-core/pull/165))
+
+### Changed
+
+- Update shared workflows ([#165](https://github.com/farcaster-project/farcaster-core/pull/165))
+
 ## [0.2.0] - 2021-10-29
 
 ### Added

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,8 @@ Releases of this crate are fairly automated.
 
 To create a new release:
 
-1. Trigger [this](https://github.com/farcaster-project/farcaster-core/actions/workflows/draft-new-release.yml) workflow with the desired version number.
-2. Merge the resulting PR (watch your notifications).
+1. Make sure `CHANGELOG.md` is up-to-date and contain all modifications under the `[Unreleased]` section.
+2. Trigger [this](https://github.com/farcaster-project/farcaster-core/actions/workflows/draft-new-release.yml) workflow with the desired version number.
+3. Merge the resulting PR (watch your notifications).
 
 The `[Unreleased]` section of `CHANGELOG.md` must contain all the changes that will be documented for the release.

--- a/dprint.json
+++ b/dprint.json
@@ -5,7 +5,7 @@
   "toml": {
   },
   "includes": ["**/*.{md,toml}"],
-  "excludes": [],
+  "excludes": ["target"],
   "plugins": [
     "https://plugins.dprint.dev/markdown-0.11.0.wasm",
     "https://plugins.dprint.dev/toml-0.5.2.wasm"


### PR DESCRIPTION
Use in release-to-crates-io
```yaml
  workflow_run:
    workflows: ["Create release"]
    types:
      - completed
```
to trigger publish after release.