### PR TITLE
Fix CI workflow run

### DIFF
--- a/.github/workflows/release-to-crates-io.yml
+++ b/.github/workflows/release-to-crates-io.yml
@@ -2,9 +2,10 @@ name: Release to crates.io
 
 on:
   release:
-    types: [ created ]
+    types: [created]
   workflow_run:
     workflows: ["Create release"]
+    branches: [main]
     types:
       - completed
 
@@ -12,5 +13,6 @@ jobs:
   release:
     name: "Publish the new release to crates.io"
     uses: farcaster-project/workflows/.github/workflows/release-to-crates-io.yml@v1.0.2
+    if: ${{ github.event.workflow_run.conclusion == 'success' }} || ${{ github.event.release }}
     secrets:
       cratesio_token: ${{ secrets.H4SH3D_CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Only run release to crates.io if create release status is success