### PR TITLE
Remove pin for parity backend crypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ rand = { version = "0.8.4", optional = true }
 rand_alt = { package = "rand", version = "0.7.3", features = ["std"] }
 rand_chacha = { version = "0.3.1", optional = true }
 secp256kfun = { version = "0.6", default-features = false, features = ["std", "serde", "libsecp_compat"], optional = true }
-secp256kfun_parity_backend = "=0.1.5"
 sha2 = { version = "0.9", optional = true }
 sha3 = "0.9.1"
 


### PR DESCRIPTION
Problematic version has been yanked, pin is unecessary now.