### PR TITLE
Reimplement serde for `SwapId`, `OfferId` and `PublicOfferId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add prefix `Offer` to serialized public offer ([#173](https://github.com/farcaster-project/farcaster-core/pull/173))
 - Switch from hex format to base58 (monero) format with checksum verification ([#171](https://github.com/farcaster-project/farcaster-core/pull/171))
 - Update monero requirement from 0.15 to 0.16 ([#175](https://github.com/farcaster-project/farcaster-core/pull/175))
+- Reimplement serde for `SwapId`, `OfferId` and `PublicOfferId` ([#176](https://github.com/farcaster-project/farcaster-core/pull/176))
 
 ## [0.3.0] - 2021-11-01
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,0 +1,33 @@
+#[cfg(feature = "serde")]
+use std::fmt;
+
+#[cfg(feature = "serde")]
+use serde_crate::de::{self, Unexpected, Visitor};
+
+/// A visitor that deserializes a long string - a string containing at least
+/// some minimum number of bytes.
+#[cfg(feature = "serde")]
+pub(crate) struct HashString;
+
+#[cfg(feature = "serde")]
+impl<'de> Visitor<'de> for HashString {
+    type Value = String;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            formatter,
+            "a string representing a hash in hex value prefixed with 0x"
+        )
+    }
+
+    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        if s.len() == 66 {
+            Ok(s.to_string())
+        } else {
+            Err(de::Error::invalid_value(Unexpected::Str(s), &self))
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub mod bitcoin;
 pub mod blockchain;
 pub mod bundle;
 pub mod crypto;
+pub(crate) mod hash;
 pub mod instruction;
 pub mod monero;
 pub mod negotiation;

--- a/src/negotiation.rs
+++ b/src/negotiation.rs
@@ -21,6 +21,10 @@
 
 use bitcoin::secp256k1::PublicKey;
 use inet2_addr::InetSocketAddr;
+#[cfg(feature = "serde")]
+use serde_crate::{de, Deserialize, Deserializer, Serialize, Serializer};
+#[cfg(feature = "serde")]
+use std::str::FromStr;
 use thiserror::Error;
 use tiny_keccak::{Hasher, Keccak};
 
@@ -28,6 +32,8 @@ use std::io;
 
 use crate::blockchain::{Asset, Fee, FeeStrategy, Network, Timelock};
 use crate::consensus::{self, serialize, serialize_hex, CanonicalBytes, Decodable, Encodable};
+#[cfg(feature = "serde")]
+use crate::hash::HashString;
 use crate::role::{SwapRole, TradeRole};
 use crate::swap::Swap;
 
@@ -93,10 +99,26 @@ fixed_hash::construct_fixed_hash!(
     pub struct OfferId(32);
 );
 
-impl OfferId {
-    /// Return the 32-bytes hash array.
-    pub fn to_bytes(&self) -> [u8; 32] {
-        self.0
+#[cfg(feature = "serde")]
+impl Serialize for OfferId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(format!("{:#x}", self).as_ref())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for OfferId {
+    fn deserialize<D>(deserializer: D) -> Result<OfferId, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(
+            OfferId::from_str(&deserializer.deserialize_string(HashString)?)
+                .map_err(de::Error::custom)?,
+        )
     }
 }
 
@@ -424,10 +446,26 @@ fixed_hash::construct_fixed_hash!(
     pub struct PublicOfferId(32);
 );
 
-impl PublicOfferId {
-    /// Return the 32-bytes hash array.
-    pub fn to_bytes(&self) -> [u8; 32] {
-        self.0
+#[cfg(feature = "serde")]
+impl Serialize for PublicOfferId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(format!("{:#x}", self).as_ref())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for PublicOfferId {
+    fn deserialize<D>(deserializer: D) -> Result<PublicOfferId, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(
+            PublicOfferId::from_str(&deserializer.deserialize_string(HashString)?)
+                .map_err(de::Error::custom)?,
+        )
     }
 }
 

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -3,23 +3,47 @@
 
 use std::fmt::{self, Debug};
 use std::io;
+#[cfg(feature = "serde")]
+use std::str::FromStr;
 
 use crate::consensus::{self, CanonicalBytes, Decodable, Encodable};
+#[cfg(feature = "serde")]
+use crate::hash::HashString;
 use crate::role::{Accordant, Arbitrating};
 
 use lightning_encoding::strategies::AsStrict;
+#[cfg(feature = "serde")]
+use serde_crate::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 pub mod btcxmr;
 
 fixed_hash::construct_fixed_hash!(
     /// A unique swap identifier represented as an 32 bytes hash.
-    #[cfg_attr(
-        feature = "serde",
-        derive(Serialize, Deserialize),
-        serde(crate = "serde_crate"),
-    )]
     pub struct SwapId(32);
 );
+
+#[cfg(feature = "serde")]
+impl Serialize for SwapId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(format!("{:#x}", self).as_ref())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for SwapId {
+    fn deserialize<D>(deserializer: D) -> Result<SwapId, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(
+            SwapId::from_str(&deserializer.deserialize_string(HashString)?)
+                .map_err(de::Error::custom)?,
+        )
+    }
+}
 
 impl Encodable for SwapId {
     fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
@@ -55,4 +79,35 @@ pub trait Swap: Debug + Clone {
 
     /// Commitment type used in the commit/reveal scheme during swap setup.
     type Commitment: Clone + PartialEq + Eq + Debug + fmt::Display + CanonicalBytes;
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "serde")]
+    use super::*;
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serialize_swapid_in_yaml() {
+        let swap_id =
+            SwapId::from_str("0x1baf1b36075de25a0f8e914b36759cac6f5d825622f8ccee597d87d4850c0d38")
+                .expect("Valid hex string");
+        let s = serde_yaml::to_string(&swap_id).expect("Encode swap id in yaml");
+        assert_eq!(
+            "---\n\"0x1baf1b36075de25a0f8e914b36759cac6f5d825622f8ccee597d87d4850c0d38\"\n",
+            s
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn deserialize_swapid_from_yaml() {
+        let s = "---\n\"0x1baf1b36075de25a0f8e914b36759cac6f5d825622f8ccee597d87d4850c0d38\"\n";
+        let swap_id = serde_yaml::from_str(&s).expect("Decode swap id from yaml");
+        assert_eq!(
+            SwapId::from_str("0x1baf1b36075de25a0f8e914b36759cac6f5d825622f8ccee597d87d4850c0d38")
+                .expect("Valid hex string"),
+            swap_id
+        );
+    }
 }


### PR DESCRIPTION
Implement manually `serde` for hash ids so they serialize as string containing the full hex formatted content of the hash.