### PR TITLE
Add Display offer implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `Display` implementation for `Offer` type ([#188](https://github.com/farcaster-project/farcaster-core/pull/188))
+
 ### Changed
 
 - Improve variants for `FromStr` network parsing ([#184](https://github.com/farcaster-project/farcaster-core/pull/184))

--- a/src/bitcoin/segwitv0.rs
+++ b/src/bitcoin/segwitv0.rs
@@ -1,7 +1,7 @@
 //! SegWit version 0 implementation for Bitcoin. Inner implementation of [`BitcoinSegwitV0`].
 
 use std::convert::TryFrom;
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::str::FromStr;
 
 use crate::bitcoin::segwitv0::{
@@ -59,6 +59,12 @@ pub type RefundTx = Tx<Refund>;
 pub struct SegwitV0;
 
 impl Strategy for SegwitV0 {}
+
+impl fmt::Display for Bitcoin<SegwitV0> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Bitcoin<SegwitV0>")
+    }
+}
 
 impl FromStr for Bitcoin<SegwitV0> {
     type Err = consensus::Error;

--- a/src/bitcoin/taproot/mod.rs
+++ b/src/bitcoin/taproot/mod.rs
@@ -2,6 +2,7 @@
 //! as Bitcoin. Inner implementation of [`BitcoinTaproot`].
 
 use std::convert::{TryFrom, TryInto};
+use std::fmt;
 use std::str::FromStr;
 
 use crate::bitcoin::{Bitcoin, BitcoinTaproot, Btc, Strategy};
@@ -20,6 +21,12 @@ use bitcoin::secp256k1::{
 pub struct Taproot;
 
 impl Strategy for Taproot {}
+
+impl fmt::Display for Bitcoin<Taproot> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Bitcoin<Taproot>")
+    }
+}
 
 impl FromStr for Bitcoin<Taproot> {
     type Err = consensus::Error;

--- a/src/bitcoin/timelock.rs
+++ b/src/bitcoin/timelock.rs
@@ -18,7 +18,7 @@ impl FromStr for CSVTimelock {
 
 /// An `OP_CSV` value (32-bits integer) to use in transactions and scripts.
 #[derive(PartialEq, Eq, PartialOrd, Clone, Debug, Copy, Display)]
-#[display("OP_CSV: {0}")]
+#[display("{0} blocks")]
 pub struct CSVTimelock(u32);
 
 impl CSVTimelock {

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -6,7 +6,7 @@
 //! or must not conflict with any registered entity.
 
 use std::error;
-use std::fmt::{self, Debug};
+use std::fmt::{self, Debug, Display};
 use std::io;
 use std::ops::Range;
 use std::str::FromStr;
@@ -32,14 +32,14 @@ pub trait Address {
 /// and is carried in the [`Offer`](crate::negotiation::Offer) to fix the two timelocks.
 pub trait Timelock {
     /// Defines the type of timelock used for the arbitrating transactions.
-    type Timelock: Copy + PartialEq + Eq + Debug + fmt::Display + CanonicalBytes;
+    type Timelock: Copy + PartialEq + Eq + Debug + Display + CanonicalBytes;
 }
 
 /// Defines the asset identifier for a blockchain and its associated asset unit type, it is carried
 /// in the [`Offer`](crate::negotiation::Offer) to fix exchanged amounts.
 pub trait Asset: Copy + Debug {
     /// Type for the traded asset unit for a blockchain.
-    type AssetUnit: Copy + Eq + Debug + CanonicalBytes;
+    type AssetUnit: Copy + Eq + Debug + Display + CanonicalBytes;
 
     /// Parse an 32 bits identifier as defined in [SLIP
     /// 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md#slip-0044--registered-coin-types-for-bip-0044)
@@ -270,7 +270,7 @@ impl FromStr for FeePriority {
 /// transactions.
 pub trait Fee: Onchain + Asset {
     /// Type for describing the fee of a blockchain.
-    type FeeUnit: Clone + PartialOrd + PartialEq + Eq + fmt::Display + Debug + CanonicalBytes;
+    type FeeUnit: Clone + PartialOrd + PartialEq + Eq + Display + Debug + CanonicalBytes;
 
     /// Calculates and sets the fee on the given transaction and return the amount of fee set in
     /// the blockchain native amount format.

--- a/src/negotiation.rs
+++ b/src/negotiation.rs
@@ -28,6 +28,7 @@ use std::str::FromStr;
 use thiserror::Error;
 use tiny_keccak::{Hasher, Keccak};
 
+use std::fmt;
 use std::io;
 
 use crate::blockchain::{Asset, Fee, FeeStrategy, Network, Timelock};
@@ -162,6 +163,21 @@ impl<Ctx: Swap> std::hash::Hash for Offer<Ctx> {
         H: std::hash::Hasher,
     {
         hasher.write(&consensus::serialize(self)[..]);
+    }
+}
+
+impl<Ctx: Swap> fmt::Display for Offer<Ctx> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "Network: {}", self.network)?;
+        writeln!(f, "Blockchain: {}", self.arbitrating_blockchain)?;
+        writeln!(f, "- amount: {}", self.arbitrating_amount)?;
+        writeln!(f, "Blockchain: {}", self.accordant_blockchain)?;
+        writeln!(f, "- amount: {}", self.accordant_amount)?;
+        writeln!(f, "Timelocks")?;
+        writeln!(f, "- cancel: {}", self.cancel_timelock)?;
+        writeln!(f, "- punish: {}", self.punish_timelock)?;
+        writeln!(f, "Fee strategy: {}", self.fee_strategy)?;
+        writeln!(f, "Maker swap role: {}", self.maker_role)
     }
 }
 
@@ -660,6 +676,11 @@ mod tests {
             Err(consensus::Error::IncorrectMagicBytes) => (),
             _ => panic!("Should have return an error IncorrectMagicBytes"),
         }
+    }
+
+    #[test]
+    fn display_offer() {
+        assert_eq!(&format!("{}", *OFFER), "Network: Testnet\nBlockchain: Bitcoin<SegwitV0>\n- amount: 0.00001350 BTC\nBlockchain: \n- amount: 0.000000010000 XMR\nTimelocks\n- cancel: 4 blocks\n- punish: 6 blocks\nFee strategy: Fixed: 1 satoshi/vByte\nMaker swap role: Bob\n");
     }
 
     #[test]

--- a/src/role.rs
+++ b/src/role.rs
@@ -2,7 +2,7 @@
 //! Defines the trading roles and swap roles distributed among participants and blockchain roles
 //! implemented on Bitcoin, Monero, etc.
 
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::io;
 use std::str::FromStr;
 
@@ -30,7 +30,8 @@ use crate::Res;
 
 /// Possible roles during the negotiation phase. Any negotiation role can transition into any swap
 /// role when negotiation is completed, the transition is described in the public offer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
+#[display(Debug)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -88,18 +89,10 @@ impl FromStr for TradeRole {
     }
 }
 
-impl ToString for TradeRole {
-    fn to_string(&self) -> String {
-        match self {
-            TradeRole::Maker => "Maker".to_string(),
-            TradeRole::Taker => "Taker".to_string(),
-        }
-    }
-}
-
 /// Possible roles during the swap phase. When negotitation phase is completed [`TradeRole`] will
 /// transition into swap role according to the [`PublicOffer`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
+#[display(Debug)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -153,15 +146,6 @@ impl FromStr for SwapRole {
             "Alice" | "alice" => Ok(SwapRole::Alice),
             "Bob" | "bob" => Ok(SwapRole::Bob),
             _ => Err(consensus::Error::UnknownType),
-        }
-    }
-}
-
-impl ToString for SwapRole {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Alice => "Alice".to_string(),
-            Self::Bob => "Bob".to_string(),
         }
     }
 }
@@ -1329,6 +1313,8 @@ pub trait Arbitrating:
     + Timelock
     + Transactions
     + SharedSecretKeys
+    + Display
+    + Debug
     + Clone
     + Eq
 {
@@ -1336,7 +1322,9 @@ pub trait Arbitrating:
 
 /// An accordant is the blockchain which does not need transaction inside the protocol nor
 /// timelocks: it is the blockchain with fewer requirements for an atomic swap.
-pub trait Accordant: Asset + Address + Keys + SharedSecretKeys + Clone + Eq {
+pub trait Accordant:
+    Asset + Address + Keys + SharedSecretKeys + Clone + Eq + Display + Debug
+{
     /// Derive the lock address for the accordant blockchain.
     fn derive_lock_address(
         network: Network,


### PR DESCRIPTION
Fix #186

Implements `fmt::Display` on `Offer` along other types. Change some `ToString` impl with proper `Display` for better genericity.

~Relax clippy warnings and add msrv in case of new breaking rules.~