### PR TITLE
Add bitcoin variant for Bitcoin<Segwit> FromStr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `"monero"` and `"xmr"` variants for Monero `FromStr` impl ([#192](https://github.com/farcaster-project/farcaster-core/pull/192))
+- Add `"bitcoin"` variant for `Bitcoin<Segwit>` implementation of `FromStr` ([#193](https://github.com/farcaster-project/farcaster-core/pull/193))
 
 ### Fixed
 

--- a/src/bitcoin/segwitv0.rs
+++ b/src/bitcoin/segwitv0.rs
@@ -71,7 +71,7 @@ impl FromStr for Bitcoin<SegwitV0> {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "SegwitV0" | "ECDSA" => Ok(Self::new()),
+            "SegwitV0" | "ECDSA" | "Bitcoin" | "bitcoin" => Ok(Self::new()),
             _ => Err(consensus::Error::UnknownType),
         }
     }
@@ -507,6 +507,10 @@ mod tests {
         let parse = Bitcoin::<SegwitV0>::from_str("SegwitV0");
         assert!(parse.is_ok());
         let parse = Bitcoin::<SegwitV0>::from_str("ECDSA");
+        assert!(parse.is_ok());
+        let parse = Bitcoin::<SegwitV0>::from_str("Bitcoin");
+        assert!(parse.is_ok());
+        let parse = Bitcoin::<SegwitV0>::from_str("bitcoin");
         assert!(parse.is_ok());
     }
 }


### PR DESCRIPTION
For now we only use the `Bitcoin<SegwitV0>` struct and have `Bitcoin|bitcoin` FromStr is handy for the node.

After `Coin` is introduced for all blockchain and variant this code should not be used anymore. In the meantime it is better to have this for node.