### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,14 +56,14 @@ sha2 = { version = "0.9", optional = true }
 sha3 = "0.10"
 
 # blockchain specific
-bitcoin = "0.28.0-rc.1"
+bitcoin = "0.28.0"
 monero = { version = "0.16" }
 
 [dev-dependencies]
-bitcoincore-rpc = "0.14"
+bitcoincore-rpc = "0.15"
 lazy_static = "1.4"
-rand_core = { version = "^0.6.3", features = ["getrandom"] }
-secp256k1 = { version = "0.21", features = ["rand-std"] }
+rand_core = { version = "0.6.3", features = ["getrandom"] }
+secp256k1 = { version = "0.22", features = ["rand-std"] }
 serde_yaml = "0.8"
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,23 +47,23 @@ tiny-keccak = { version = "2", features = ["keccak"] }
 
 bincode = { version = "1", optional = true }
 curve25519-dalek = "3"
-ecdsa_fun = { version = "0.6", default-features = false, features = ["all"], optional = true }
+ecdsa_fun = { version = "0.7", default-features = false, features = ["all"], optional = true }
 rand = { version = "0.8.4", optional = true }
 rand_alt = { package = "rand", version = "0.7.3", features = ["std"] }
 rand_chacha = { version = "0.3.1", optional = true }
-secp256kfun = { version = "0.6", default-features = false, features = ["std", "serde", "libsecp_compat"], optional = true }
+secp256kfun = { version = "0.7", default-features = false, features = ["std", "serde", "libsecp_compat"], optional = true }
 sha2 = { version = "0.9", optional = true }
 sha3 = "0.10"
 
 # blockchain specific
-bitcoin = "0.27"
+bitcoin = "0.28.0-rc.1"
 monero = { version = "0.16" }
 
 [dev-dependencies]
 bitcoincore-rpc = "0.14"
 lazy_static = "1.4"
 rand_core = { version = "^0.6.3", features = ["getrandom"] }
-secp256k1 = { version = "0.20", features = ["rand-std"] }
+secp256k1 = { version = "0.21", features = ["rand-std"] }
 serde_yaml = "0.8"
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,30 +30,30 @@ default = ["experimental", "taproot"]
 
 [dependencies]
 amplify = "3"
-base58-monero = { version = "0.3.1", default-features = false, features = ["check"] }
-bitcoin_hashes = { version = "0.10.0" }
-bitvec = { version = "0.22.3" }
-fixed-hash = { version = "0.7.0", default-features = false }
-hex = "0.4.3"
-inet2_addr = { version = "0.5.0", default-features = false, features = ["tor", "strict_encoding"] }
-lightning_encoding = "=0.5.0-beta.3"
+base58-monero = { version = "0.3", default-features = false, features = ["check"] }
+bitcoin_hashes = { version = "0.10" }
+bitvec = { version = "0.22" }
+fixed-hash = { version = "0.7", default-features = false }
+hex = "0.4"
+inet2_addr = { version = "0.6", default-features = false, features = ["tor", "strict_encoding"] }
+lightning_encoding = "0.6"
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
-strict_encoding = "1.7.4"
-strict_encoding_derive = "1.7.4"
-thiserror = "1.0.24"
+strict_encoding = "1.8"
+strict_encoding_derive = "1.7"
+thiserror = "1"
 tiny-keccak = { version = "2", features = ["keccak"] }
 
 # crypto libs
 
-bincode = { version = "1.3.3", optional = true }
-curve25519-dalek = "3.0.2"
+bincode = { version = "1", optional = true }
+curve25519-dalek = "3"
 ecdsa_fun = { version = "0.6", default-features = false, features = ["all"], optional = true }
 rand = { version = "0.8.4", optional = true }
 rand_alt = { package = "rand", version = "0.7.3", features = ["std"] }
 rand_chacha = { version = "0.3.1", optional = true }
 secp256kfun = { version = "0.6", default-features = false, features = ["std", "serde", "libsecp_compat"], optional = true }
 sha2 = { version = "0.9", optional = true }
-sha3 = "0.10.1"
+sha3 = "0.10"
 
 # blockchain specific
 bitcoin = "0.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,11 +47,11 @@ tiny-keccak = { version = "2", features = ["keccak"] }
 
 bincode = { version = "1", optional = true }
 curve25519-dalek = "3"
-ecdsa_fun = { version = "0.7", default-features = false, features = ["all"], optional = true }
+ecdsa_fun = { git = "https://github.com/farcaster-project/secp256kfun.git", branch = "secp256k1/0.22", default-features = false, features = ["all"], optional = true }
 rand = { version = "0.8.4", optional = true }
 rand_alt = { package = "rand", version = "0.7.3", features = ["std"] }
 rand_chacha = { version = "0.3.1", optional = true }
-secp256kfun = { version = "0.7", default-features = false, features = ["std", "serde", "libsecp_compat"], optional = true }
+secp256kfun = { git = "https://github.com/farcaster-project/secp256kfun.git", branch = "secp256k1/0.22", default-features = false, features = ["std", "serde", "libsecp_compat"], optional = true }
 sha2 = { version = "0.9", optional = true }
 sha3 = "0.10"
 

--- a/contrib/run-rpc-tests.sh
+++ b/contrib/run-rpc-tests.sh
@@ -2,18 +2,31 @@
 
 cd ..
 
-ID=$(docker run --rm -d -p 18443:18443 coblox/bitcoin-core\
+docker pull ghcr.io/farcaster-project/containers/bitcoin-core:23.0
+docker run --rm -d -p 18443:18443 --name=bitcoind ghcr.io/farcaster-project/containers/bitcoin-core:23.0\
+    /usr/bin/bitcoind\
     -regtest\
     -server\
     -fallbackfee=0.00001\
     -rpcbind=0.0.0.0\
     -rpcallowip=0.0.0.0/0\
     -rpcuser=test\
-    -rpcpassword=cEl2o3tHHgzYeuu3CiiZ2FjdgSiw9wNeMFzoNbFmx9k=)
+    -rpcpassword=cEl2o3tHHgzYeuu3CiiZ2FjdgSiw9wNeMFzoNbFmx9k=
+
+res="null"
+while [[ "$res" = "null" ]]
+do
+    echo "Wating for node to start..."
+    rpc=$(curl --user test:cEl2o3tHHgzYeuu3CiiZ2FjdgSiw9wNeMFzoNbFmx9k= --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getblockhash", "params": [0]}' -H 'content-type: text/plain;' http://127.0.0.1:18443/) || sleep 1
+    if [ "$rpc" = "" ]; then
+        continue
+    fi
+    res=$(echo "$rpc" | jq '.result')
+done
 
 export CI=false RPC_USER=test RPC_PASS=cEl2o3tHHgzYeuu3CiiZ2FjdgSiw9wNeMFzoNbFmx9k=
 cargo test --test transactions --features rpc -- --test-threads=1
 
-docker kill $ID
+docker kill bitcoind
 
 cd -

--- a/src/bitcoin/fee.rs
+++ b/src/bitcoin/fee.rs
@@ -137,7 +137,12 @@ impl<S: Strategy> Fee for Bitcoin<S> {
         // FIXME This does not account for witnesses
         // currently the fees are wrong
         // Get the transaction weight
-        let weight = tx.unsigned_tx.get_weight() as u64;
+        //
+        // For transactions with an empty witness, this is simply the consensus-serialized size
+        // times four. For transactions with a witness, this is the non-witness
+        // consensus-serialized size multiplied by three plus the with-witness consensus-serialized
+        // size.
+        let weight = tx.unsigned_tx.weight() as u64;
 
         // Compute the fee amount to set in total
         let fee_amount = match strategy {
@@ -175,7 +180,7 @@ impl<S: Strategy> Fee for Bitcoin<S> {
         let fee = input_sum
             .checked_sub(output_sum)
             .ok_or(FeeStrategyError::AmountOfFeeTooHigh)?;
-        let weight = tx.unsigned_tx.get_weight() as u64;
+        let weight = tx.unsigned_tx.weight() as u64;
 
         let effective_sat_per_vbyte = SatPerVByte::from_sat(
             weight

--- a/src/bitcoin/fee.rs
+++ b/src/bitcoin/fee.rs
@@ -126,7 +126,7 @@ impl<S: Strategy> Fee for Bitcoin<S> {
         strategy: &FeeStrategy<SatPerVByte>,
         politic: FeePriority,
     ) -> Result<Amount, FeeStrategyError> {
-        if tx.global.unsigned_tx.output.len() != 1 {
+        if tx.unsigned_tx.output.len() != 1 {
             return Err(FeeStrategyError::new(
                 transaction::Error::MultiUTXOUnsuported,
             ));
@@ -137,7 +137,7 @@ impl<S: Strategy> Fee for Bitcoin<S> {
         // FIXME This does not account for witnesses
         // currently the fees are wrong
         // Get the transaction weight
-        let weight = tx.global.unsigned_tx.get_weight() as u64;
+        let weight = tx.unsigned_tx.get_weight() as u64;
 
         // Compute the fee amount to set in total
         let fee_amount = match strategy {
@@ -150,7 +150,7 @@ impl<S: Strategy> Fee for Bitcoin<S> {
         .ok_or(FeeStrategyError::AmountOfFeeTooHigh)?;
 
         // Apply the fee on the first output
-        tx.global.unsigned_tx.output[0].value = input_sum
+        tx.unsigned_tx.output[0].value = input_sum
             .checked_sub(fee_amount)
             .ok_or(FeeStrategyError::NotEnoughAssets)?
             .as_sat();
@@ -164,18 +164,18 @@ impl<S: Strategy> Fee for Bitcoin<S> {
         tx: &PartiallySignedTransaction,
         strategy: &FeeStrategy<SatPerVByte>,
     ) -> Result<bool, FeeStrategyError> {
-        if tx.global.unsigned_tx.output.len() != 1 {
+        if tx.unsigned_tx.output.len() != 1 {
             return Err(FeeStrategyError::new(
                 transaction::Error::MultiUTXOUnsuported,
             ));
         }
 
         let input_sum = get_available_input_sat(tx)?.as_sat();
-        let output_sum = tx.global.unsigned_tx.output[0].value;
+        let output_sum = tx.unsigned_tx.output[0].value;
         let fee = input_sum
             .checked_sub(output_sum)
             .ok_or(FeeStrategyError::AmountOfFeeTooHigh)?;
-        let weight = tx.global.unsigned_tx.get_weight() as u64;
+        let weight = tx.unsigned_tx.get_weight() as u64;
 
         let effective_sat_per_vbyte = SatPerVByte::from_sat(
             weight
@@ -196,6 +196,7 @@ mod tests {
         for s in [
             "0.0001 BTC/vByte",
             "100 satoshi/vByte",
+            "100 satoshis/vByte",
             "10 satoshi/vByte",
             "1 satoshi/vByte",
         ]
@@ -205,7 +206,7 @@ mod tests {
             assert!(parse.is_ok());
         }
         // MUST fail
-        for s in ["100 satoshis/vByte", "1 satoshi", "100 vByte"].iter() {
+        for s in ["1 satoshi", "100 vByte"].iter() {
             let parse = SatPerVByte::from_str(s);
             assert!(parse.is_err());
         }

--- a/src/bitcoin/segwitv0.rs
+++ b/src/bitcoin/segwitv0.rs
@@ -19,10 +19,10 @@ use crate::script::{DataLock, DataPunishableLock, DoubleKeys, ScriptPath};
 
 use bitcoin::blockdata::opcodes;
 use bitcoin::blockdata::script::{Builder, Instruction, Script};
-use bitcoin::blockdata::transaction::EcdsaSigHashType;
+use bitcoin::blockdata::transaction::EcdsaSighashType;
 use bitcoin::hashes::sha256d::Hash as Sha256dHash;
 use bitcoin::secp256k1::{ecdsa::Signature, Message, PublicKey, Secp256k1, SecretKey, Signing};
-use bitcoin::util::sighash::SigHashCache;
+use bitcoin::util::sighash::SighashCache;
 
 use ecdsa_fun::adaptor::EncryptedSignature;
 
@@ -445,9 +445,9 @@ pub fn signature_hash(
     txin: TxInRef,
     script: &Script,
     value: u64,
-    sighash_type: EcdsaSigHashType,
+    sighash_type: EcdsaSighashType,
 ) -> Sha256dHash {
-    SigHashCache::new(txin.transaction)
+    SighashCache::new(txin.transaction)
         .segwit_signature_hash(txin.index, script, value, sighash_type)
         .expect("encoding works")
         .as_hash()
@@ -461,7 +461,7 @@ pub fn sign_input<C>(
     txin: TxInRef,
     script: &Script,
     value: u64,
-    sighash_type: EcdsaSigHashType,
+    sighash_type: EcdsaSighashType,
     secret_key: &bitcoin::secp256k1::SecretKey,
 ) -> Result<Signature, bitcoin::secp256k1::Error>
 where

--- a/src/bitcoin/segwitv0/buy.rs
+++ b/src/bitcoin/segwitv0/buy.rs
@@ -1,7 +1,9 @@
 use std::marker::PhantomData;
 
-use bitcoin::blockdata::transaction::{SigHashType, TxIn, TxOut};
-use bitcoin::secp256k1::Signature;
+use bitcoin::blockdata::transaction::{TxIn, TxOut};
+use bitcoin::blockdata::witness::Witness;
+use bitcoin::secp256k1::ecdsa::Signature;
+use bitcoin::util::ecdsa::EcdsaSig;
 use bitcoin::util::psbt::PartiallySignedTransaction;
 use bitcoin::Address;
 
@@ -37,7 +39,11 @@ impl SubTransaction for Buy {
             .ok_or(FError::MissingSignature)?
             .clone();
 
-        psbt.inputs[0].final_script_witness = Some(vec![bob_sig, alice_sig, script.into_bytes()]);
+        psbt.inputs[0].final_script_witness = Some(Witness::from_vec(vec![
+            bob_sig.to_vec(),
+            alice_sig.to_vec(),
+            script.into_bytes(),
+        ]));
 
         Ok(())
     }
@@ -58,7 +64,7 @@ impl Buyable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Buy> {
                 previous_output: output_metadata.out_point,
                 script_sig: bitcoin::Script::default(),
                 sequence: 0,
-                witness: vec![],
+                witness: Witness::new(),
             }],
             output: vec![TxOut {
                 value: output_metadata.tx_out.value,
@@ -72,7 +78,6 @@ impl Buyable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Buy> {
         // Set the input witness data and sighash type
         psbt.inputs[0].witness_utxo = Some(output_metadata.tx_out);
         psbt.inputs[0].witness_script = output_metadata.script_pubkey;
-        psbt.inputs[0].sighash_type = Some(SigHashType::All);
 
         Ok(Tx {
             psbt,
@@ -81,25 +86,25 @@ impl Buyable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Buy> {
     }
 
     fn verify_template(&self, destination_target: Address) -> Result<(), FError> {
-        (self.psbt.global.unsigned_tx.version == 2)
+        (self.psbt.unsigned_tx.version == 2)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("Tx version is not 2"))?;
-        (self.psbt.global.unsigned_tx.lock_time == 0)
+        (self.psbt.unsigned_tx.lock_time == 0)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("LockTime is not set to 0"))?;
-        (self.psbt.global.unsigned_tx.input.len() == 1)
+        (self.psbt.unsigned_tx.input.len() == 1)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("Number of inputs is not 1"))?;
-        (self.psbt.global.unsigned_tx.output.len() == 1)
+        (self.psbt.unsigned_tx.output.len() == 1)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("Number of outputs is not 1"))?;
 
-        let txin = &self.psbt.global.unsigned_tx.input[0];
+        let txin = &self.psbt.unsigned_tx.input[0];
         (txin.sequence == 0)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("Sequence is not set to 0"))?;
 
-        let txout = &self.psbt.global.unsigned_tx.output[0];
+        let txout = &self.psbt.unsigned_tx.output[0];
         let script_pubkey = destination_target.script_pubkey();
         (txout.script_pubkey == script_pubkey)
             .then(|| 0)
@@ -110,9 +115,9 @@ impl Buyable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Buy> {
 
     fn extract_witness(tx: bitcoin::Transaction) -> Signature {
         let TxIn { witness, .. } = &tx.input[0];
-        let bytes: &[u8] = witness[0].as_ref();
-        // Remove SIGHASH type at the end of the signature
-        Signature::from_der(&bytes[..bytes.len() - 1])
-            .expect("Validated transaction on-chain, signature and witness position is correct.")
+        let witness_bytes = witness.to_vec();
+        let ecdsa_sig = EcdsaSig::from_slice(witness_bytes[1].as_ref())
+            .expect("Validated transaction on-chain, signature and witness position is correct.");
+        ecdsa_sig.sig
     }
 }

--- a/src/bitcoin/segwitv0/buy.rs
+++ b/src/bitcoin/segwitv0/buy.rs
@@ -116,7 +116,7 @@ impl Buyable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Buy> {
     fn extract_witness(tx: bitcoin::Transaction) -> Signature {
         let TxIn { witness, .. } = &tx.input[0];
         let witness_bytes = witness.to_vec();
-        let ecdsa_sig = EcdsaSig::from_slice(witness_bytes[1].as_ref())
+        let ecdsa_sig = EcdsaSig::from_slice(witness_bytes[0].as_ref())
             .expect("Validated transaction on-chain, signature and witness position is correct.");
         ecdsa_sig.sig
     }

--- a/src/bitcoin/segwitv0/buy.rs
+++ b/src/bitcoin/segwitv0/buy.rs
@@ -29,13 +29,17 @@ impl SubTransaction for Buy {
 
         let alice_sig = psbt.inputs[0]
             .partial_sigs
-            .get(swaplock.get_pubkey(SwapRole::Alice))
+            .get(&bitcoin::PublicKey::new(
+                *swaplock.get_pubkey(SwapRole::Alice),
+            ))
             .ok_or(FError::MissingSignature)?
             .clone();
 
         let bob_sig = psbt.inputs[0]
             .partial_sigs
-            .get(swaplock.get_pubkey(SwapRole::Bob))
+            .get(&bitcoin::PublicKey::new(
+                *swaplock.get_pubkey(SwapRole::Bob),
+            ))
             .ok_or(FError::MissingSignature)?
             .clone();
 

--- a/src/bitcoin/segwitv0/cancel.rs
+++ b/src/bitcoin/segwitv0/cancel.rs
@@ -26,13 +26,17 @@ impl SubTransaction for Cancel {
 
         let alice_sig = psbt.inputs[0]
             .partial_sigs
-            .get(swaplock.get_pubkey(SwapRole::Alice))
+            .get(&bitcoin::PublicKey::new(
+                *swaplock.get_pubkey(SwapRole::Alice),
+            ))
             .ok_or(FError::MissingSignature)?
             .clone();
 
         let bob_sig = psbt.inputs[0]
             .partial_sigs
-            .get(swaplock.get_pubkey(SwapRole::Bob))
+            .get(&bitcoin::PublicKey::new(
+                *swaplock.get_pubkey(SwapRole::Bob),
+            ))
             .ok_or(FError::MissingSignature)?
             .clone();
 

--- a/src/bitcoin/segwitv0/cancel.rs
+++ b/src/bitcoin/segwitv0/cancel.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
-use bitcoin::blockdata::transaction::{SigHashType, TxIn, TxOut};
+use bitcoin::blockdata::transaction::{TxIn, TxOut};
+use bitcoin::blockdata::witness::Witness;
 use bitcoin::util::psbt::PartiallySignedTransaction;
 
 use crate::role::SwapRole;
@@ -35,7 +36,11 @@ impl SubTransaction for Cancel {
             .ok_or(FError::MissingSignature)?
             .clone();
 
-        psbt.inputs[0].final_script_witness = Some(vec![bob_sig, alice_sig, script.into_bytes()]);
+        psbt.inputs[0].final_script_witness = Some(Witness::from_vec(vec![
+            bob_sig.to_vec(),
+            alice_sig.to_vec(),
+            script.into_bytes(),
+        ]));
 
         Ok(())
     }
@@ -57,7 +62,7 @@ impl Cancelable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Cancel> {
                 previous_output: output_metadata.out_point,
                 script_sig: bitcoin::Script::default(),
                 sequence: lock.timelock.as_u32(),
-                witness: vec![],
+                witness: Witness::new(),
             }],
             output: vec![TxOut {
                 value: output_metadata.tx_out.value,
@@ -71,7 +76,6 @@ impl Cancelable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Cancel> {
         // Set the input witness data and sighash type
         psbt.inputs[0].witness_utxo = Some(output_metadata.tx_out);
         psbt.inputs[0].witness_script = output_metadata.script_pubkey;
-        psbt.inputs[0].sighash_type = Some(SigHashType::All);
 
         // Set the script witness of the output
         psbt.outputs[0].witness_script = Some(script);
@@ -87,27 +91,27 @@ impl Cancelable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Cancel> {
         lock: script::DataLock<Bitcoin<SegwitV0>>,
         punish_lock: script::DataPunishableLock<Bitcoin<SegwitV0>>,
     ) -> Result<(), FError> {
-        (self.psbt.global.unsigned_tx.version == 2)
+        (self.psbt.unsigned_tx.version == 2)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("Tx version is not 2"))?;
-        (self.psbt.global.unsigned_tx.lock_time == 0)
+        (self.psbt.unsigned_tx.lock_time == 0)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("LockTime is not set to 0"))?;
-        (self.psbt.global.unsigned_tx.input.len() == 1)
+        (self.psbt.unsigned_tx.input.len() == 1)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("Number of inputs is not 1"))?;
-        (self.psbt.global.unsigned_tx.output.len() == 1)
+        (self.psbt.unsigned_tx.output.len() == 1)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("Number of outputs is not 1"))?;
 
-        let txin = &self.psbt.global.unsigned_tx.input[0];
+        let txin = &self.psbt.unsigned_tx.input[0];
         (txin.sequence == lock.timelock.as_u32())
             .then(|| 0)
             .ok_or(FError::WrongTemplate(
                 "Sequence is not set correctly for timelock",
             ))?;
 
-        let txout = &self.psbt.global.unsigned_tx.output[0];
+        let txout = &self.psbt.unsigned_tx.output[0];
         let script_pubkey = PunishLock::v0_p2wsh(punish_lock);
         (txout.script_pubkey == script_pubkey)
             .then(|| 0)

--- a/src/bitcoin/segwitv0/funding.rs
+++ b/src/bitcoin/segwitv0/funding.rs
@@ -2,7 +2,7 @@
 
 use bitcoin::blockdata::transaction::{OutPoint, Transaction};
 use bitcoin::network::constants::Network as BtcNetwork;
-use bitcoin::secp256k1::key::PublicKey;
+use bitcoin::secp256k1::PublicKey;
 use bitcoin::Address;
 
 use crate::blockchain::Network;
@@ -25,7 +25,7 @@ impl Linkable<MetadataOutput> for Funding {
     fn get_consumable_output(&self) -> Result<MetadataOutput, FError> {
         // Create a **COMPRESSED** ECDSA public key.
         let pubkey = match self.pubkey {
-            Some(pubkey) => bitcoin::util::ecdsa::PublicKey::new(pubkey),
+            Some(pubkey) => bitcoin::util::key::PublicKey::new(pubkey),
             None => return Err(FError::MissingPublicKey),
         };
 
@@ -79,7 +79,7 @@ impl Fundable<Bitcoin<SegwitV0>, MetadataOutput> for Funding {
 
     fn get_address(&self) -> Result<Address, FError> {
         let pubkey = match self.pubkey {
-            Some(pubkey) => Ok(bitcoin::util::ecdsa::PublicKey::new(pubkey)),
+            Some(pubkey) => Ok(bitcoin::util::key::PublicKey::new(pubkey)),
             None => Err(FError::MissingPublicKey),
         }?;
 

--- a/src/bitcoin/segwitv0/lock.rs
+++ b/src/bitcoin/segwitv0/lock.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
-use bitcoin::blockdata::transaction::{SigHashType, TxIn, TxOut};
+use bitcoin::blockdata::transaction::{TxIn, TxOut};
+use bitcoin::blockdata::witness::Witness;
 use bitcoin::util::psbt::PartiallySignedTransaction;
 use bitcoin::Amount;
 
@@ -22,7 +23,10 @@ impl SubTransaction for Lock {
             .iter()
             .next()
             .ok_or(FError::MissingSignature)?;
-        psbt.inputs[0].final_script_witness = Some(vec![full_sig.clone(), pubkey.to_bytes()]);
+        psbt.inputs[0].final_script_witness = Some(Witness::from_vec(vec![
+            full_sig.to_vec(),
+            pubkey.serialize().to_vec(),
+        ]));
         Ok(())
     }
 }
@@ -47,7 +51,7 @@ impl Lockable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Lock> {
                 previous_output: output_metadata.out_point,
                 script_sig: bitcoin::Script::default(),
                 sequence: CSVTimelock::disable(),
-                witness: vec![],
+                witness: Witness::new(),
             }],
             output: vec![TxOut {
                 value: target_amount.as_sat(),
@@ -61,7 +65,6 @@ impl Lockable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Lock> {
         // Set the input witness data and sighash type
         psbt.inputs[0].witness_utxo = Some(output_metadata.tx_out);
         psbt.inputs[0].witness_script = output_metadata.script_pubkey;
-        psbt.inputs[0].sighash_type = Some(SigHashType::All);
 
         // Set the script witness of the output
         psbt.outputs[0].witness_script = Some(script);
@@ -73,25 +76,25 @@ impl Lockable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Lock> {
     }
 
     fn verify_template(&self, lock: script::DataLock<Bitcoin<SegwitV0>>) -> Result<(), FError> {
-        (self.psbt.global.unsigned_tx.version == 2)
+        (self.psbt.unsigned_tx.version == 2)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("Tx version is not 2"))?;
-        (self.psbt.global.unsigned_tx.lock_time == 0)
+        (self.psbt.unsigned_tx.lock_time == 0)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("LockTime is not set to 0"))?;
-        (self.psbt.global.unsigned_tx.input.len() == 1)
+        (self.psbt.unsigned_tx.input.len() == 1)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("Number of inputs is not 1"))?;
-        (self.psbt.global.unsigned_tx.output.len() == 1)
+        (self.psbt.unsigned_tx.output.len() == 1)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("Number of outputs is not 1"))?;
 
-        let txin = &self.psbt.global.unsigned_tx.input[0];
+        let txin = &self.psbt.unsigned_tx.input[0];
         (txin.sequence == CSVTimelock::disable())
             .then(|| 0)
             .ok_or(FError::WrongTemplate("Sequence timelock is not disabled"))?;
 
-        let txout = &self.psbt.global.unsigned_tx.output[0];
+        let txout = &self.psbt.unsigned_tx.output[0];
         let script_pubkey = CoopLock::v0_p2wsh(lock);
         (txout.script_pubkey == script_pubkey)
             .then(|| 0)

--- a/src/bitcoin/segwitv0/lock.rs
+++ b/src/bitcoin/segwitv0/lock.rs
@@ -25,7 +25,7 @@ impl SubTransaction for Lock {
             .ok_or(FError::MissingSignature)?;
         psbt.inputs[0].final_script_witness = Some(Witness::from_vec(vec![
             full_sig.to_vec(),
-            pubkey.serialize().to_vec(),
+            pubkey.to_bytes(),
         ]));
         Ok(())
     }

--- a/src/bitcoin/segwitv0/punish.rs
+++ b/src/bitcoin/segwitv0/punish.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
-use bitcoin::blockdata::transaction::{SigHashType, TxIn, TxOut};
+use bitcoin::blockdata::transaction::{TxIn, TxOut};
+use bitcoin::blockdata::witness::Witness;
 use bitcoin::util::psbt::PartiallySignedTransaction;
 use bitcoin::Address;
 
@@ -35,11 +36,11 @@ impl SubTransaction for Punish {
             .ok_or(Error::MissingSignature)?
             .clone();
 
-        psbt.inputs[0].final_script_witness = Some(vec![
-            punish_sig,
+        psbt.inputs[0].final_script_witness = Some(Witness::from_vec(vec![
+            punish_sig.to_vec(),
             vec![], // OP_FALSE
             script.into_bytes(),
-        ]);
+        ]));
         Ok(())
     }
 }
@@ -59,7 +60,7 @@ impl Punishable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Punish> {
                 previous_output: output_metadata.out_point,
                 script_sig: bitcoin::Script::default(),
                 sequence: punish_lock.timelock.as_u32(),
-                witness: vec![],
+                witness: Witness::new(),
             }],
             output: vec![TxOut {
                 value: output_metadata.tx_out.value,
@@ -73,7 +74,6 @@ impl Punishable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Punish> {
         // Set the input witness data and sighash type
         psbt.inputs[0].witness_utxo = Some(output_metadata.tx_out);
         psbt.inputs[0].witness_script = output_metadata.script_pubkey;
-        psbt.inputs[0].sighash_type = Some(SigHashType::All);
 
         Ok(Tx {
             psbt,

--- a/src/bitcoin/segwitv0/punish.rs
+++ b/src/bitcoin/segwitv0/punish.rs
@@ -28,11 +28,11 @@ impl SubTransaction for Punish {
 
         let punish_sig = psbt.inputs[0]
             .partial_sigs
-            .get(
-                swaplock
+            .get(&bitcoin::PublicKey::new(
+                *swaplock
                     .get_pubkey(SwapRole::Alice, ScriptPath::Success)
                     .ok_or(Error::MissingPublicKey)?,
-            )
+            ))
             .ok_or(Error::MissingSignature)?
             .clone();
 

--- a/src/bitcoin/segwitv0/refund.rs
+++ b/src/bitcoin/segwitv0/refund.rs
@@ -29,21 +29,21 @@ impl SubTransaction for Refund {
 
         let alice_sig = psbt.inputs[0]
             .partial_sigs
-            .get(
-                swaplock
+            .get(&bitcoin::PublicKey::new(
+                *swaplock
                     .get_pubkey(SwapRole::Alice, ScriptPath::Success)
                     .ok_or(FError::MissingPublicKey)?,
-            )
+            ))
             .ok_or(FError::MissingSignature)?
             .clone();
 
         let bob_sig = psbt.inputs[0]
             .partial_sigs
-            .get(
-                swaplock
+            .get(&bitcoin::PublicKey::new(
+                *swaplock
                     .get_pubkey(SwapRole::Bob, ScriptPath::Success)
                     .ok_or(FError::MissingPublicKey)?,
-            )
+            ))
             .ok_or(FError::MissingSignature)?
             .clone();
 

--- a/src/bitcoin/segwitv0/refund.rs
+++ b/src/bitcoin/segwitv0/refund.rs
@@ -1,7 +1,9 @@
 use std::marker::PhantomData;
 
-use bitcoin::blockdata::transaction::{SigHashType, TxIn, TxOut};
-use bitcoin::secp256k1::Signature;
+use bitcoin::blockdata::transaction::{TxIn, TxOut};
+use bitcoin::blockdata::witness::Witness;
+use bitcoin::secp256k1::ecdsa::Signature;
+use bitcoin::util::ecdsa::EcdsaSig;
 use bitcoin::util::psbt::PartiallySignedTransaction;
 use bitcoin::Address;
 
@@ -45,12 +47,12 @@ impl SubTransaction for Refund {
             .ok_or(FError::MissingSignature)?
             .clone();
 
-        psbt.inputs[0].final_script_witness = Some(vec![
-            bob_sig,
-            alice_sig,
+        psbt.inputs[0].final_script_witness = Some(Witness::from_vec(vec![
+            bob_sig.to_vec(),
+            alice_sig.to_vec(),
             vec![1],             // OP_TRUE
             script.into_bytes(), // cancel script
-        ]);
+        ]));
 
         Ok(())
     }
@@ -70,7 +72,7 @@ impl Refundable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Refund> {
                 previous_output: output_metadata.out_point,
                 script_sig: bitcoin::Script::default(),
                 sequence: 0,
-                witness: vec![],
+                witness: Witness::new(),
             }],
             output: vec![TxOut {
                 value: output_metadata.tx_out.value,
@@ -84,7 +86,6 @@ impl Refundable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Refund> {
         // Set the input witness data and sighash type
         psbt.inputs[0].witness_utxo = Some(output_metadata.tx_out);
         psbt.inputs[0].witness_script = output_metadata.script_pubkey;
-        psbt.inputs[0].sighash_type = Some(SigHashType::All);
 
         Ok(Tx {
             psbt,
@@ -93,25 +94,25 @@ impl Refundable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Refund> {
     }
 
     fn verify_template(&self, refund_target: Address) -> Result<(), FError> {
-        (self.psbt.global.unsigned_tx.version == 2)
+        (self.psbt.unsigned_tx.version == 2)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("Tx version is not 2"))?;
-        (self.psbt.global.unsigned_tx.lock_time == 0)
+        (self.psbt.unsigned_tx.lock_time == 0)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("LockTime is not set to 0"))?;
-        (self.psbt.global.unsigned_tx.input.len() == 1)
+        (self.psbt.unsigned_tx.input.len() == 1)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("Number of inputs is not 1"))?;
-        (self.psbt.global.unsigned_tx.output.len() == 1)
+        (self.psbt.unsigned_tx.output.len() == 1)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("Number of outputs is not 1"))?;
 
-        let txin = &self.psbt.global.unsigned_tx.input[0];
+        let txin = &self.psbt.unsigned_tx.input[0];
         (txin.sequence == 0)
             .then(|| 0)
             .ok_or(FError::WrongTemplate("Sequence is not set to 0"))?;
 
-        let txout = &self.psbt.global.unsigned_tx.output[0];
+        let txout = &self.psbt.unsigned_tx.output[0];
         let script_pubkey = refund_target.script_pubkey();
         (txout.script_pubkey == script_pubkey)
             .then(|| 0)
@@ -122,9 +123,9 @@ impl Refundable<Bitcoin<SegwitV0>, MetadataOutput> for Tx<Refund> {
 
     fn extract_witness(tx: bitcoin::Transaction) -> Signature {
         let TxIn { witness, .. } = &tx.input[0];
-        let bytes: &[u8] = witness[1].as_ref();
-        // Remove SIGHASH type at the end of the signature
-        Signature::from_der(&bytes[..bytes.len() - 1])
-            .expect("Validated transaction on-chain, signature and witness position is correct.")
+        let witness_bytes = witness.to_vec();
+        let ecdsa_sig = EcdsaSig::from_slice(witness_bytes[1].as_ref())
+            .expect("Validated transaction on-chain, signature and witness position is correct.");
+        ecdsa_sig.sig
     }
 }

--- a/src/bitcoin/taproot/mod.rs
+++ b/src/bitcoin/taproot/mod.rs
@@ -11,10 +11,7 @@ use crate::crypto::{Keys, SharedKeyId, SharedSecretKeys, Signatures};
 //use crate::role::Arbitrating;
 
 use bitcoin::hashes::sha256d::Hash as Sha256dHash;
-use bitcoin::secp256k1::{
-    constants::SECRET_KEY_SIZE,
-    schnorrsig::{KeyPair, PublicKey, Signature},
-};
+use bitcoin::secp256k1::{constants::SECRET_KEY_SIZE, schnorr::Signature, KeyPair, XOnlyPublicKey};
 
 /// Inner type for the Taproot strategy with on-chain scripts.
 #[derive(Clone, Debug, Copy, Eq, PartialEq)]
@@ -60,7 +57,7 @@ impl TryFrom<Btc> for Bitcoin<Taproot> {
 
 impl Keys for Bitcoin<Taproot> {
     type SecretKey = KeyPair;
-    type PublicKey = PublicKey;
+    type PublicKey = XOnlyPublicKey;
 
     fn extra_keys() -> Vec<u16> {
         // No extra key
@@ -68,7 +65,7 @@ impl Keys for Bitcoin<Taproot> {
     }
 }
 
-impl CanonicalBytes for PublicKey {
+impl CanonicalBytes for XOnlyPublicKey {
     fn as_canonical_bytes(&self) -> Vec<u8> {
         self.serialize().as_ref().into()
     }
@@ -77,7 +74,7 @@ impl CanonicalBytes for PublicKey {
     where
         Self: Sized,
     {
-        PublicKey::from_slice(bytes).map_err(consensus::Error::new)
+        XOnlyPublicKey::from_slice(bytes).map_err(consensus::Error::new)
     }
 }
 

--- a/src/bitcoin/transaction.rs
+++ b/src/bitcoin/transaction.rs
@@ -193,7 +193,9 @@ where
 
     fn add_witness(&mut self, pubkey: PublicKey, sig: Signature) -> Result<(), FError> {
         let sig_all = EcdsaSig::sighash_all(sig);
-        self.psbt.inputs[0].partial_sigs.insert(bitcoin::PublicKey::new(pubkey), sig_all);
+        self.psbt.inputs[0]
+            .partial_sigs
+            .insert(bitcoin::PublicKey::new(pubkey), sig_all);
         Ok(())
     }
 }

--- a/src/bitcoin/transaction.rs
+++ b/src/bitcoin/transaction.rs
@@ -4,14 +4,15 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 
 use bitcoin::blockdata::script::Script;
-use bitcoin::blockdata::transaction::{OutPoint, TxIn, TxOut};
+use bitcoin::blockdata::transaction::{EcdsaSigHashType, OutPoint, TxIn, TxOut};
 use bitcoin::util::address;
+use bitcoin::util::ecdsa::EcdsaSig;
 use bitcoin::util::psbt::{self, PartiallySignedTransaction};
 
 #[cfg(feature = "experimental")]
 use bitcoin::{
     hashes::sha256d::Hash,
-    secp256k1::{key::PublicKey, Signature},
+    secp256k1::{ecdsa::Signature, PublicKey},
     Amount,
 };
 
@@ -110,14 +111,14 @@ where
 
     fn based_on(&self) -> MetadataOutput {
         MetadataOutput {
-            out_point: self.psbt.global.unsigned_tx.input[0].previous_output,
+            out_point: self.psbt.unsigned_tx.input[0].previous_output,
             tx_out: self.psbt.inputs[0].witness_utxo.clone().unwrap(), // FIXME
             script_pubkey: self.psbt.inputs[0].witness_script.clone(),
         }
     }
 
     fn output_amount(&self) -> Amount {
-        Amount::from_sat(self.psbt.global.unsigned_tx.output[0].value)
+        Amount::from_sat(self.psbt.unsigned_tx.output[0].value)
     }
 }
 
@@ -145,10 +146,10 @@ where
     T: SubTransaction,
 {
     fn get_consumable_output(&self) -> Result<MetadataOutput, FError> {
-        match self.psbt.global.unsigned_tx.output.len() {
+        match self.psbt.unsigned_tx.output.len() {
             1 => (),
             2 => {
-                if !self.psbt.global.unsigned_tx.is_coin_base() {
+                if !self.psbt.unsigned_tx.is_coin_base() {
                     return Err(FError::new(Error::MultiUTXOUnsuported));
                 }
             }
@@ -156,8 +157,8 @@ where
         }
 
         Ok(MetadataOutput {
-            out_point: OutPoint::new(self.psbt.global.unsigned_tx.txid(), 0),
-            tx_out: self.psbt.global.unsigned_tx.output[0].clone(),
+            out_point: OutPoint::new(self.psbt.unsigned_tx.txid(), 0),
+            tx_out: self.psbt.unsigned_tx.output[0].clone(),
             script_pubkey: self.psbt.outputs[0].witness_script.clone(),
         })
     }
@@ -173,7 +174,7 @@ where
     /// This function is used for generating the witness message for all transactions but not
     /// funding. So implying only 1 input is valid as all templates only have 1 input.
     fn generate_witness_message(&self, _path: ScriptPath) -> Result<Hash, FError> {
-        let unsigned_tx = self.psbt.global.unsigned_tx.clone();
+        let unsigned_tx = self.psbt.unsigned_tx.clone();
         let txin = TxInRef::new(&unsigned_tx, 0);
 
         let witness_utxo = self.psbt.inputs[0]
@@ -187,21 +188,12 @@ where
             .ok_or(FError::MissingWitness)?;
         let value = witness_utxo.value;
 
-        let sighash_type = self.psbt.inputs[0]
-            .sighash_type
-            .ok_or_else(|| FError::new(Error::MissingSigHashType))?;
-
-        Ok(signature_hash(txin, &script, value, sighash_type))
+        Ok(signature_hash(txin, &script, value, EcdsaSigHashType::All))
     }
 
     fn add_witness(&mut self, pubkey: PublicKey, sig: Signature) -> Result<(), FError> {
-        let sighash_type = self.psbt.inputs[0]
-            .sighash_type
-            .ok_or_else(|| FError::new(Error::MissingSigHashType))?;
-        let mut full_sig = sig.serialize_der().to_vec();
-        full_sig.extend_from_slice(&[sighash_type.as_u32() as u8]);
-        let pubkey = bitcoin::util::ecdsa::PublicKey::new(pubkey);
-        self.psbt.inputs[0].partial_sigs.insert(pubkey, full_sig);
+        let sig_all = EcdsaSig::sighash_all(sig);
+        self.psbt.inputs[0].partial_sigs.insert(pubkey, sig_all);
         Ok(())
     }
 }

--- a/src/bitcoin/transaction.rs
+++ b/src/bitcoin/transaction.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 
 use bitcoin::blockdata::script::Script;
-use bitcoin::blockdata::transaction::{EcdsaSigHashType, OutPoint, TxIn, TxOut};
+use bitcoin::blockdata::transaction::{EcdsaSighashType, OutPoint, TxIn, TxOut};
 use bitcoin::util::address;
 use bitcoin::util::ecdsa::EcdsaSig;
 use bitcoin::util::psbt::{self, PartiallySignedTransaction};
@@ -188,12 +188,12 @@ where
             .ok_or(FError::MissingWitness)?;
         let value = witness_utxo.value;
 
-        Ok(signature_hash(txin, &script, value, EcdsaSigHashType::All))
+        Ok(signature_hash(txin, &script, value, EcdsaSighashType::All))
     }
 
     fn add_witness(&mut self, pubkey: PublicKey, sig: Signature) -> Result<(), FError> {
         let sig_all = EcdsaSig::sighash_all(sig);
-        self.psbt.inputs[0].partial_sigs.insert(pubkey, sig_all);
+        self.psbt.inputs[0].partial_sigs.insert(bitcoin::PublicKey::new(pubkey), sig_all);
         Ok(())
     }
 }

--- a/src/crypto/slip10.rs
+++ b/src/crypto/slip10.rs
@@ -401,7 +401,7 @@ mod tests {
 
         assert_eq!(asserts[0], res.parent_fingerprint.to_string());
         assert_eq!(asserts[1], res.chain_code.to_string());
-        assert_eq!(asserts[2], res.secret_key.to_string());
+        assert_eq!(asserts[2], res.secret_key.display_secret().to_string());
         assert_eq!(asserts[3], res.public_key(&ctx).to_string());
     }
 

--- a/src/negotiation.rs
+++ b/src/negotiation.rs
@@ -675,9 +675,9 @@ mod tests {
     lazy_static::lazy_static! {
         pub static ref NODE_ID: PublicKey = {
             let sk =
-                bitcoin::PrivateKey::from_wif("L1HKVVLHXiUhecWnwFYF6L3shkf1E12HUmuZTESvBXUdx3yqVP1D")
+                bitcoin::util::key::PrivateKey::from_wif("L1HKVVLHXiUhecWnwFYF6L3shkf1E12HUmuZTESvBXUdx3yqVP1D")
                     .unwrap()
-                    .key;
+                    .inner;
             secp256k1::PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &sk)
         };
 

--- a/src/swap/btcxmr.rs
+++ b/src/swap/btcxmr.rs
@@ -27,12 +27,11 @@ use rand_chacha::ChaCha20Rng;
 use sha2::Sha256;
 
 #[cfg(feature = "experimental")]
-use bitcoin::{hashes::sha256d::Hash as Sha256dHash, secp256k1::Message, secp256k1::Signature};
-
-use bitcoin::secp256k1::{
-    key::{PublicKey, SecretKey},
-    Secp256k1,
+use bitcoin::{
+    hashes::sha256d::Hash as Sha256dHash, secp256k1::ecdsa::Signature, secp256k1::Message,
 };
+
+use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -298,7 +297,8 @@ impl Sign<PublicKey, SecretKey, Sha256dHash, Signature, EncryptedSignature> for 
     ) -> Result<(), crypto::Error> {
         let secp = Secp256k1::new();
         let message = Message::from_slice(&msg).expect("Hash is always ok");
-        secp.verify(&message, sig, key).map_err(crypto::Error::new)
+        secp.verify_ecdsa(&message, sig, key)
+            .map_err(crypto::Error::new)
     }
 
     fn encrypt_sign(

--- a/tests/negotiation.rs
+++ b/tests/negotiation.rs
@@ -90,9 +90,11 @@ fn serialize_public_offer() {
     let port = FromStr::from_str("9735").unwrap();
 
     let secp = secp256k1::Secp256k1::new();
-    let sk = bitcoin::PrivateKey::from_wif("L1HKVVLHXiUhecWnwFYF6L3shkf1E12HUmuZTESvBXUdx3yqVP1D")
-        .unwrap()
-        .key;
+    let sk = bitcoin::util::key::PrivateKey::from_wif(
+        "L1HKVVLHXiUhecWnwFYF6L3shkf1E12HUmuZTESvBXUdx3yqVP1D",
+    )
+    .unwrap()
+    .inner;
     let node_id = secp256k1::PublicKey::from_secret_key(&secp, &sk);
     let peer_address = InetSocketAddr::new(ip, port);
     let public_offer = offer.to_public_v1(node_id, peer_address);

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -16,6 +16,7 @@ use farcaster_core::swap::SwapId;
 use farcaster_core::transaction::*;
 
 use bitcoin::blockdata::transaction::{OutPoint, TxIn, TxOut};
+use bitcoin::blockdata::witness::Witness;
 use bitcoin::secp256k1::{PublicKey, Secp256k1};
 use bitcoin::Address;
 
@@ -118,7 +119,7 @@ fn execute_offline_protocol() {
             previous_output: OutPoint::null(),
             script_sig: bitcoin::blockdata::script::Script::default(),
             sequence: (1 << 31) as u32, // activate disable flag on CSV
-            witness: vec![],
+            witness: Witness::new(),
         }],
         output: vec![TxOut {
             value: 123456789,

--- a/tests/rpc/mod.rs
+++ b/tests/rpc/mod.rs
@@ -61,7 +61,7 @@ macro_rules! new_address {
         let pair = s.generate_keypair(&mut thread_rng());
         let public_key = key::PublicKey {
             compressed: true,
-            key: pair.1,
+            inner: pair.1,
         };
 
         // Generate pay-to-pubkey-hash address


### PR DESCRIPTION
* `bitcoin` to version **0.28**
* `secp256k1` to version **0.22**
* custom `secp256kfun` to bump secp from 0.21 to 0.22 (need to be upstreamed before releasing a new core version to crates.io)
* bump lnp-bp related crates to latest versions