### PR TITLE
Revert "Release version 0.4.5"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.5] - 2022-05-27
-
 ### Added
 
 - Extend serde coverage
@@ -122,8 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Messages exchanged between farcaster-node's microservices
 - Tasks and blockchain events used by syncers
 
-[Unreleased]: https://github.com/farcaster-project/farcaster-core/compare/v0.4.5...HEAD
-[0.4.5]: https://github.com/farcaster-project/farcaster-core/compare/v0.4.4...v0.4.5
+[Unreleased]: https://github.com/farcaster-project/farcaster-core/compare/v0.4.4...HEAD
 [0.4.4]: https://github.com/farcaster-project/farcaster-core/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/farcaster-project/farcaster-core/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/farcaster-project/farcaster-core/compare/v0.4.1...v0.4.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "farcaster_core"
-version = "0.4.5"
+version = "0.4.4"
 authors = ["Farcaster Devs"]
 documentation = "https://docs.rs/farcaster_core"
 homepage = "https://github.com/farcaster-project/farcaster-core"


### PR DESCRIPTION
Reverts the release in farcaster-project/farcaster-core#234 as it cannot be published on crates.io because of a git dependency.