### PR TITLE
Pin bitcoin-core version used in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
 
     services:
       bitcoind:
-        image: ghcr.io/farcaster-project/containers/bitcoin-core
+        image: ghcr.io/farcaster-project/containers/bitcoin-core:23.0
         env:
           NETWORK: regtest
           RPC_PORT: 18443


### PR DESCRIPTION
To avoid having issues with `latest` tag moving on our containers when we do updates we pin to current latest: `23.0`.