### PR TITLE
Fix bitvec dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump dependencies
 - Bump MSRV (Minimum Supported Rust Version) from 1.54.0 to 1.56.1
+- Bump bitvec to version 1
 
 ## [0.4.4] - 2022-02-27
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ default = ["experimental", "taproot"]
 amplify = "3"
 base58-monero = { version = "0.3", default-features = false, features = ["check"] }
 bitcoin_hashes = { version = "0.10" }
-bitvec = { version = "0.22" }
+bitvec = { version = "1.0" }
 fixed-hash = { version = "0.7", default-features = false }
 hex = "0.4"
 inet2_addr = { version = "0.6", default-features = false, features = ["tor", "strict_encoding"] }

--- a/src/crypto/dleq.rs
+++ b/src/crypto/dleq.rs
@@ -194,7 +194,7 @@ impl From<(bool, usize, secp256k1Scalar)> for PedersenCommitment<secp256k1Point,
 }
 
 fn key_commitment(
-    x_bits: &BitSlice<Lsb0, u8>,
+    x_bits: &BitSlice<u8, Lsb0>,
     msb_index: usize,
 ) -> Vec<PedersenCommitment<ed25519Point, ed25519Scalar>> {
     let mut commitment: Vec<PedersenCommitment<ed25519Point, ed25519Scalar>> = x_bits
@@ -216,7 +216,7 @@ fn key_commitment(
 }
 
 fn key_commitment_secp256k1(
-    x_bits: &BitSlice<Lsb0, u8>,
+    x_bits: &BitSlice<u8, Lsb0>,
     msb_index: usize,
 ) -> Vec<PedersenCommitment<secp256k1Point, secp256k1Scalar>> {
     let mut commitment: Vec<PedersenCommitment<secp256k1Point, secp256k1Scalar>> = x_bits
@@ -706,7 +706,7 @@ impl DLEQProof {
         // convention: start count at 0
         let msb_index = 251;
 
-        let x_bits = BitSlice::<Lsb0, u8>::from_slice(&x).unwrap();
+        let x_bits = BitSlice::<u8, Lsb0>::from_slice(&x);
 
         assert!(x_bits[msb_index + 1..].iter().all(|bit| !(*bit)));
 

--- a/src/crypto/dleq.rs
+++ b/src/crypto/dleq.rs
@@ -867,7 +867,7 @@ mod tests {
         let mut x: [u8; 32] = rand::thread_rng().gen();
         // ensure 256th bit is 0
         x[31] &= 0b0111_1111;
-        let x_bits = BitSlice::<Lsb0, u8>::from_slice(&x).unwrap();
+        let x_bits = BitSlice::<u8, Lsb0>::from_slice(&x);
         let key_commitment = key_commitment(x_bits, 255);
         let commitment_acc = key_commitment.iter().map(|pc| pc.commitment).sum();
         assert_eq!(ed25519Scalar::from_bytes_mod_order(x) * G, commitment_acc);
@@ -880,7 +880,7 @@ mod tests {
         // let mut x: [u8; 32] = rand::thread_rng().gen();
         // ensure 256th bit is 0
         // x[31] &= 0b0111_1111;
-        let x_bits = BitSlice::<Lsb0, u8>::from_slice(&x).unwrap();
+        let x_bits = BitSlice::<u8, Lsb0>::from_slice(&x);
         let key_commitment = key_commitment_secp256k1(x_bits, 255);
         // let commitment_acc: secp256k1Point<Jacobian, Public, Zero> = key_commitment
         let commitment_acc = key_commitment.iter().fold(
@@ -915,7 +915,7 @@ mod tests {
     fn blinders_sum_to_zero() {
         use rand::Rng;
         let x: [u8; 32] = rand::thread_rng().gen();
-        let x_bits = BitSlice::<Lsb0, u8>::from_slice(&x).unwrap();
+        let x_bits = BitSlice::<u8, Lsb0>::from_slice(&x);
         let key_commitment = key_commitment(x_bits, 255);
         let blinder_acc = key_commitment
             .iter()


### PR DESCRIPTION
This pull request is to fix the compilation errors of #212 in order to upgrade bitvec's dependencies to the latest version. I have done below modifications to crypto/dleq.rs:

- Modified the order of BitSlice's parameters accordingly with the latest version as it is expecting the following input format <u8, Lsb0>
- Removed unwrap() as already called in bitvec from_slice() function