### PR TITLE
refactor: split crypto sign trait and clean crypto module

### DIFF
--- a/src/bitcoin/segwitv0.rs
+++ b/src/bitcoin/segwitv0.rs
@@ -14,7 +14,7 @@ use crate::bitcoin::{Bitcoin, BitcoinSegwitV0, Btc, Strategy};
 use crate::bitcoin::timelock::CSVTimelock;
 use crate::blockchain::Transactions;
 use crate::consensus::{self, CanonicalBytes};
-use crate::crypto::{DeriveKeys, SharedKeyId, Signatures};
+use crate::crypto::{DeriveKeys, SharedKeyId};
 use crate::role::SwapRole;
 use crate::script::{DataLock, DataPunishableLock, DoubleKeys, ScriptPath};
 
@@ -398,11 +398,11 @@ impl CanonicalBytes for SecretKey {
     }
 }
 
-impl Signatures for Bitcoin<SegwitV0> {
-    type Message = Sha256dHash;
-    type Signature = Signature;
-    type EncryptedSignature = EncryptedSignature;
-}
+//impl Signatures for Bitcoin<SegwitV0> {
+//    type Message = Sha256dHash;
+//    type Signature = Signature;
+//    type EncryptedSignature = EncryptedSignature;
+//}
 
 impl CanonicalBytes for Signature {
     fn as_canonical_bytes(&self) -> Vec<u8> {

--- a/src/bitcoin/segwitv0.rs
+++ b/src/bitcoin/segwitv0.rs
@@ -398,12 +398,6 @@ impl CanonicalBytes for SecretKey {
     }
 }
 
-//impl Signatures for Bitcoin<SegwitV0> {
-//    type Message = Sha256dHash;
-//    type Signature = Signature;
-//    type EncryptedSignature = EncryptedSignature;
-//}
-
 impl CanonicalBytes for Signature {
     fn as_canonical_bytes(&self) -> Vec<u8> {
         self.serialize_compact().into()

--- a/src/bitcoin/taproot/mod.rs
+++ b/src/bitcoin/taproot/mod.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 
 use crate::bitcoin::{Bitcoin, BitcoinTaproot, Btc, Strategy};
 use crate::consensus::{self, CanonicalBytes};
-use crate::crypto::{DeriveKeys, SharedKeyId, Signatures};
+use crate::crypto::{DeriveKeys, SharedKeyId};
 //use crate::role::Arbitrating;
 
 use bitcoin::hashes::sha256d::Hash as Sha256dHash;
@@ -83,11 +83,11 @@ impl CanonicalBytes for XOnlyPublicKey {
     }
 }
 
-impl Signatures for Bitcoin<Taproot> {
-    type Message = Sha256dHash;
-    type Signature = Signature;
-    type EncryptedSignature = Signature;
-}
+//impl Signatures for Bitcoin<Taproot> {
+//    type Message = Sha256dHash;
+//    type Signature = Signature;
+//    type EncryptedSignature = Signature;
+//}
 
 impl CanonicalBytes for Signature {
     fn as_canonical_bytes(&self) -> Vec<u8> {

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -13,7 +13,6 @@ use std::str::FromStr;
 use thiserror::Error;
 
 use crate::consensus::{self, deserialize, serialize, CanonicalBytes, Decodable, Encodable};
-use crate::crypto::Signatures;
 use crate::transaction::{Buyable, Cancelable, Fundable, Lockable, Punishable, Refundable};
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Display)]

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -411,10 +411,9 @@ pub trait GenerateSharedKey<SharedKey> {
 
 // TODO give extra keys and/or shared keys in signing methods
 
-/// Signature and encrypted signature generator and verifier. Produce and verify signatures and
-/// encrypted sigantures based on public keys/key identifiers. Recover the private key through the
-/// complete encrypted/decrypted signature.
-pub trait Sign<PublicKey, SecretKey, Message, Signature, EncryptedSignature> {
+/// Signature generator and verifier. Produce and verify signatures based on public keys/key
+/// identifiers.
+pub trait Sign<PublicKey, Message, Signature> {
     /// Sign the message with the corresponding private key identified by the provided arbitrating
     /// key identifier.
     fn sign(&mut self, key: ArbitratingKeyId, msg: Message) -> Result<Signature, Error>;
@@ -422,7 +421,12 @@ pub trait Sign<PublicKey, SecretKey, Message, Signature, EncryptedSignature> {
     /// Verify a signature for a given message with the provided public key.
     fn verify_signature(&self, key: &PublicKey, msg: Message, sig: &Signature)
         -> Result<(), Error>;
+}
 
+/// Encrypted signature generator and verifier. Produce and verify encrypted sigantures based on
+/// public keys/key identifiers.  Decrypt encrypted signature through key identifier to recover
+/// signature.
+pub trait EncSign<PublicKey, Message, Signature, EncryptedSignature> {
     /// Sign the message with the corresponding private key identified by the provided arbitrating
     /// key identifier and encrypt it (create an adaptor signature) with the provided encryption
     /// public key.
@@ -450,7 +454,11 @@ pub trait Sign<PublicKey, SecretKey, Message, Signature, EncryptedSignature> {
         decryption_key: AccordantKeyId,
         sig: EncryptedSignature,
     ) -> Result<Signature, Error>;
+}
 
+/// Recover the secret key through the complete encrypted/decrypted signature and public
+/// encryption key.
+pub trait RecoverSecret<PublicKey, SecretKey, Signature, EncryptedSignature> {
     /// Recover the encryption key based on the encrypted signature, the encryption public key, and
     /// the regular (decrypted) signature.
     fn recover_secret_key(

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -453,14 +453,17 @@ pub trait RecoverSecret<PublicKey, SecretKey, Signature, EncryptedSignature> {
 
 /// Commitment generator and verifier. Generated commitments can be validated against candidates,
 /// if correct the commit/reveal process is validated.
-pub trait Commit<Commitment: Eq> {
+pub trait Commit<Commitment> {
     /// Provides a generic method to commit to any value referencable as stream of bytes.
     fn commit_to<T: AsRef<[u8]>>(&self, value: T) -> Commitment;
 
     /// Validate the equality between a candidate and a commitment, return `Ok(())` if the value
     /// commits to the same commitment's candidate, return [`Error::InvalidCommitment`]
     /// otherwise.
-    fn validate<T: AsRef<[u8]>>(&self, candidate: T, commitment: Commitment) -> Result<(), Error> {
+    fn validate<T: AsRef<[u8]>>(&self, candidate: T, commitment: Commitment) -> Result<(), Error>
+    where
+        Commitment: Eq,
+    {
         if self.commit_to(candidate) == commitment {
             Ok(())
         } else {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -342,24 +342,6 @@ pub trait DeriveKeys {
     fn extra_shared_private_keys() -> Vec<SharedKeyId>;
 }
 
-/// Trait required for [`Arbitrating`] blockchains to define the cryptographic message format to
-/// sign, the signature format and adaptor signature format used in the cryptographic operations
-/// such as signing and verifying signatures and adaptor signatures.
-///
-/// [`Arbitrating`]: crate::role::Arbitrating
-pub trait Signatures {
-    /// Type of the message passed to sign or adaptor sign methods, transactions will produce
-    /// messages that will be passed to these methods.
-    type Message: Clone + Debug;
-
-    /// Defines the signature format for the arbitrating blockchain.
-    type Signature: Clone + Debug + fmt::Display + CanonicalBytes;
-
-    /// Defines the adaptor signature format for the arbitrating blockchain. Adaptor signature may
-    /// have a different format from the signature depending on the cryptographic primitives used.
-    type EncryptedSignature: Clone + Debug + fmt::Display + CanonicalBytes;
-}
-
 /// Meta trait regrouping all the needed trait combinations a key manager must implement to manage
 /// all the keys needed when executing the protocol on [`Alice`] and [`Bob`] methods. This trait is
 /// auto-implemented for all `T` meeting the requirements.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -7,7 +7,7 @@ use crate::blockchain::{Asset, FeeStrategy};
 use crate::consensus::{self, CanonicalBytes, Decodable, Encodable};
 use crate::crypto::{
     self, AccordantKeyId, ArbitratingKeyId, Commit, DeriveKeys, EncSign, KeyGenerator,
-    RecoverSecret, SharedKeyId, Sign, Signatures, TaggedElement, TaggedElements, TaggedExtraKeys,
+    RecoverSecret, SharedKeyId, Sign, TaggedElement, TaggedElements, TaggedExtraKeys,
     TaggedSharedKeys,
 };
 use crate::negotiation::PublicOffer;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -6,8 +6,9 @@ use crate::blockchain::{Address, Fee, FeePriority, Onchain, Timelock, Transactio
 use crate::blockchain::{Asset, FeeStrategy};
 use crate::consensus::{self, CanonicalBytes, Decodable, Encodable};
 use crate::crypto::{
-    self, AccordantKeyId, ArbitratingKeyId, Commit, DeriveKeys, KeyGenerator, SharedKeyId, Sign,
-    Signatures, TaggedElement, TaggedElements, TaggedExtraKeys, TaggedSharedKeys,
+    self, AccordantKeyId, ArbitratingKeyId, Commit, DeriveKeys, EncSign, KeyGenerator,
+    RecoverSecret, SharedKeyId, Sign, Signatures, TaggedElement, TaggedElements, TaggedExtraKeys,
+    TaggedSharedKeys,
 };
 use crate::negotiation::PublicOffer;
 use crate::protocol::message::{
@@ -430,7 +431,7 @@ where
         arb_params: ArbitratingParameters<Amt, Ti, F>,
     ) -> Res<EncSig>
     where
-        S: Sign<Pk, Rk, Ms, Si, EncSig>,
+        S: EncSign<Pk, Ms, Si, EncSig>,
         Ar: Transactions<Addr = Addr, Amt = Amt, Ti = Ti, Ms = Ms, Pk = Pk, Si = Si, Px = Px>,
         Px: Clone + Fee<FeeUnit = F>,
         Pk: Copy,
@@ -478,7 +479,7 @@ where
     ///
     /// Returns the witness inside the [`CosignedArbitratingCancel`] bundle.
     ///
-    pub fn cosign_arbitrating_cancel<Amt, Px, Pk, Qk, Rk, Sk, Ti, F, Pr, S, Ms, Si, EncSig>(
+    pub fn cosign_arbitrating_cancel<Amt, Px, Pk, Qk, Rk, Sk, Ti, F, Pr, S, Ms, Si>(
         &self,
         wallet: &mut S,
         alice_parameters: &Parameters<Pk, Qk, Rk, Sk, Addr, Ti, F, Pr>,
@@ -487,7 +488,7 @@ where
         arb_params: ArbitratingParameters<Amt, Ti, F>,
     ) -> Res<Si>
     where
-        S: Sign<Pk, Rk, Ms, Si, EncSig>,
+        S: Sign<Pk, Ms, Si>,
         Ar: Transactions<Addr = Addr, Amt = Amt, Ti = Ti, Ms = Ms, Pk = Pk, Si = Si, Px = Px>,
         Px: Clone + Fee<FeeUnit = F>,
         Pk: Copy,
@@ -543,7 +544,7 @@ where
         adaptor_buy: &BuyProcedureSignature<Px, EncSig>,
     ) -> Res<()>
     where
-        S: Sign<Pk, Rk, Ms, Si, EncSig>,
+        S: EncSign<Pk, Ms, Si, EncSig>,
         Ar: Transactions<Addr = Addr, Amt = Amt, Ti = Ti, Ms = Ms, Pk = Pk, Si = Si, Px = Px>,
         Px: Clone + Fee<FeeUnit = F>,
         Pk: Copy,
@@ -626,7 +627,7 @@ where
         adaptor_buy: &BuyProcedureSignature<Px, EncSig>,
     ) -> Res<TxSignatures<Si>>
     where
-        S: Sign<Pk, Rk, Ms, Si, EncSig>,
+        S: Sign<Pk, Ms, Si> + EncSign<Pk, Ms, Si, EncSig>,
         Ar: Transactions<Addr = Addr, Amt = Amt, Ti = Ti, Ms = Ms, Pk = Pk, Si = Si, Px = Px>,
         Px: Clone + Fee<FeeUnit = F>,
         Pk: Copy,
@@ -695,7 +696,7 @@ where
     ///
     /// [`validate_adaptor_buy`]: Alice::validate_adaptor_buy
     ///
-    pub fn fully_sign_punish<Amt, Px, Pk, Qk, Rk, Sk, Ti, F, Pr, S, Ms, Si, EncSig>(
+    pub fn fully_sign_punish<Amt, Px, Pk, Qk, Rk, Sk, Ti, F, Pr, S, Ms, Si>(
         &self,
         wallet: &mut S,
         alice_parameters: &Parameters<Pk, Qk, Rk, Sk, Addr, Ti, F, Pr>,
@@ -704,14 +705,13 @@ where
         arb_params: ArbitratingParameters<Amt, Ti, F>,
     ) -> Res<FullySignedPunish<Px, Si>>
     where
-        S: Sign<Pk, Rk, Ms, Si, EncSig>,
+        S: Sign<Pk, Ms, Si>,
         Ar: Transactions<Addr = Addr, Amt = Amt, Ti = Ti, Ms = Ms, Pk = Pk, Si = Si, Px = Px>,
         Px: Clone + Fee<FeeUnit = F>,
         Pk: Copy,
         Ti: Copy,
         F: Copy,
         Amt: Copy + PartialEq,
-        EncSig: Clone,
     {
         // Verifies the core arbitrating transactions.
         let ValidatedCoreTransactions {
@@ -743,7 +743,7 @@ where
     }
 
     // TODO: transform into other private key type
-    pub fn recover_accordant_key<Amt, Tx, Px, Pk, Qk, Rk, Sk, Ti, F, Pr, S, Ms, Si, EncSig>(
+    pub fn recover_accordant_key<Amt, Tx, Px, Pk, Qk, Rk, Sk, Ti, F, Pr, S, Si, EncSig>(
         &self,
         wallet: &mut S,
         bob_parameters: &Parameters<Pk, Qk, Rk, Sk, Addr, Ti, F, Pr>,
@@ -751,17 +751,8 @@ where
         refund_tx: Tx,
     ) -> Rk
     where
-        S: Sign<Pk, Rk, Ms, Si, EncSig>,
-        Ar: Transactions<
-            Addr = Addr,
-            Amt = Amt,
-            Ti = Ti,
-            Ms = Ms,
-            Pk = Pk,
-            Si = Si,
-            Px = Px,
-            Tx = Tx,
-        >,
+        S: RecoverSecret<Pk, Rk, Si, EncSig>,
+        Ar: Transactions<Addr = Addr, Amt = Amt, Ti = Ti, Pk = Pk, Si = Si, Px = Px, Tx = Tx>,
     {
         let encryption_key = &bob_parameters.adaptor;
         let signature = <Ar::Refund>::extract_witness(refund_tx);
@@ -1074,7 +1065,7 @@ where
     ///
     /// [`FeeStrategy`]: crate::blockchain::FeeStrategy
     ///
-    pub fn core_arbitrating_transactions<Amt, Tx, Px, Pk, Qk, Rk, Sk, Ti, F, Pr, Si, Out>(
+    pub fn core_arbitrating_transactions<Amt, Tx, Px, Pk, Qk, Rk, Sk, Ti, F, Pr, Out>(
         &self,
         alice_parameters: &Parameters<Pk, Qk, Rk, Sk, Addr, Ti, F, Pr>,
         bob_parameters: &Parameters<Pk, Qk, Rk, Sk, Addr, Ti, F, Pr>,
@@ -1082,16 +1073,7 @@ where
         arb_params: ArbitratingParameters<Amt, Ti, F>,
     ) -> Res<CoreArbitratingTransactions<Px>>
     where
-        Ar: Transactions<
-            Addr = Addr,
-            Amt = Amt,
-            Tx = Tx,
-            Out = Out,
-            Ti = Ti,
-            Pk = Pk,
-            Si = Si,
-            Px = Px,
-        >,
+        Ar: Transactions<Addr = Addr, Amt = Amt, Tx = Tx, Out = Out, Ti = Ti, Pk = Pk, Px = Px>,
         Px: Fee<FeeUnit = F>,
         Out: Eq,
         Pk: Copy,
@@ -1191,13 +1173,13 @@ where
     ///
     /// [`cosign_arbitrating_cancel`]: Bob::cosign_arbitrating_cancel
     ///
-    pub fn cosign_arbitrating_cancel<S, Px, Si, Pk, Rk, Ms, EncSig>(
+    pub fn cosign_arbitrating_cancel<S, Px, Si, Pk, Ms>(
         &self,
         wallet: &mut S,
         core: &CoreArbitratingTransactions<Px>,
     ) -> Res<Si>
     where
-        S: Sign<Pk, Rk, Ms, Si, EncSig>,
+        S: Sign<Pk, Ms, Si>,
         Ar: Transactions<Addr = Addr, Ms = Ms, Pk = Pk, Si = Si, Px = Px>,
         Px: Clone,
     {
@@ -1254,7 +1236,7 @@ where
         refund_adaptor_sig: &EncSig,
     ) -> Res<()>
     where
-        S: Sign<Pk, Rk, Ms, Si, EncSig>,
+        S: EncSign<Pk, Ms, Si, EncSig>,
         Ar: Transactions<Addr = Addr, Amt = Amt, Ti = Ti, Ms = Ms, Pk = Pk, Si = Si, Px = Px>,
         Px: Clone,
     {
@@ -1325,7 +1307,7 @@ where
         arb_params: ArbitratingParameters<Amt, Ti, F>,
     ) -> Res<BuyProcedureSignature<Px, EncSig>>
     where
-        S: Sign<Pk, Rk, Ms, Si, EncSig>,
+        S: EncSign<Pk, Ms, Si, EncSig>,
         Ar: Transactions<Addr = Addr, Amt = Amt, Ti = Ti, Ms = Ms, Pk = Pk, Si = Si, Px = Px>,
         Px: Clone + Fee<FeeUnit = F>,
         Pk: Copy,
@@ -1403,13 +1385,13 @@ where
     /// [`sign_arbitrating_lock`]: Bob::sign_arbitrating_lock
     /// [`validate_adaptor_refund`]: Bob::validate_adaptor_refund
     ///
-    pub fn sign_arbitrating_lock<S, Px, Si, Pk, Rk, Ms, EncSig>(
+    pub fn sign_arbitrating_lock<S, Px, Si, Pk, Ms>(
         &self,
         wallet: &mut S,
         core: &CoreArbitratingTransactions<Px>,
     ) -> Res<Si>
     where
-        S: Sign<Pk, Rk, Ms, Si, EncSig>,
+        S: Sign<Pk, Ms, Si>,
         Ar: Transactions<Addr = Addr, Ms = Ms, Pk = Pk, Si = Si, Px = Px>,
         Px: Clone,
     {
@@ -1453,14 +1435,14 @@ where
     ///
     /// [`validate_adaptor_refund`]: Bob::validate_adaptor_refund
     ///
-    pub fn fully_sign_refund<S, Px, Si, Pk, Rk, Ms, EncSig>(
+    pub fn fully_sign_refund<S, Px, Si, Pk, Ms, EncSig>(
         &self,
         wallet: &mut S,
         core: &CoreArbitratingTransactions<Px>,
         signed_adaptor_refund: &EncSig,
     ) -> Res<TxSignatures<Si>>
     where
-        S: Sign<Pk, Rk, Ms, Si, EncSig>,
+        S: Sign<Pk, Ms, Si> + EncSign<Pk, Ms, Si, EncSig>,
         Ar: Transactions<Addr = Addr, Ms = Ms, Pk = Pk, Si = Si, Px = Px>,
         EncSig: Clone,
         Px: Clone,
@@ -1485,7 +1467,7 @@ where
         })
     }
 
-    pub fn recover_accordant_key<S, Tx, Px, Si, Pk, Qk, Rk, Sk, Ti, F, Pr, Ms, EncSig>(
+    pub fn recover_accordant_key<S, Tx, Px, Si, Pk, Qk, Rk, Sk, Ti, F, Pr, EncSig>(
         &self,
         wallet: &mut S,
         alice_parameters: &Parameters<Pk, Qk, Rk, Sk, Addr, Ti, F, Pr>,
@@ -1493,8 +1475,8 @@ where
         buy_tx: Tx,
     ) -> Rk
     where
-        S: Sign<Pk, Rk, Ms, Si, EncSig>,
-        Ar: Transactions<Addr = Addr, Tx = Tx, Px = Px, Ms = Ms, Pk = Pk, Si = Si>,
+        S: RecoverSecret<Pk, Rk, Si, EncSig>,
+        Ar: Transactions<Addr = Addr, Tx = Tx, Px = Px, Pk = Pk, Si = Si>,
     {
         let encryption_key = &alice_parameters.adaptor;
         let signature = <Ar::Buy>::extract_witness(buy_tx);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -329,8 +329,8 @@ where
         public_offer: &PublicOffer<Amt, Bmt, Ti, F>,
     ) -> Res<Parameters<Pk, Qk, Rk, Sk, Addr, Ti, F, Pr>>
     where
-        Ar: DeriveKeys,
-        Ac: DeriveKeys,
+        Ar: DeriveKeys<PublicKey = Pk, PrivateKey = Rk>,
+        Ac: DeriveKeys<PublicKey = Qk, PrivateKey = Sk>,
         Ti: Copy,
         F: Copy,
         Kg: KeyGenerator<Pk, Qk, Rk, Sk, Pr>,
@@ -969,8 +969,8 @@ where
         public_offer: &PublicOffer<Amt, Bmt, Ti, F>,
     ) -> Res<Parameters<Pk, Qk, Rk, Sk, Addr, Ti, F, Pr>>
     where
-        Ar: DeriveKeys,
-        Ac: DeriveKeys,
+        Ar: DeriveKeys<PublicKey = Pk, PrivateKey = Rk>,
+        Ac: DeriveKeys<PublicKey = Qk, PrivateKey = Sk>,
         Ti: Copy,
         F: Clone,
         Kg: KeyGenerator<Pk, Qk, Rk, Sk, Pr>,

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -5,7 +5,7 @@ use std::io;
 
 use crate::blockchain::{Address, Onchain};
 use crate::consensus::{self, CanonicalBytes, Decodable, Encodable};
-use crate::crypto::{self, Commit, SharedKeyId, Signatures, TaggedElement, TaggedElements};
+use crate::crypto::{self, Commit, SharedKeyId, TaggedElement, TaggedElements};
 use crate::protocol::verify_vec_of_commitments;
 use crate::swap::SwapId;
 use crate::Error;

--- a/src/role.rs
+++ b/src/role.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 
 use crate::blockchain::{Address, Asset, Fee, Network, Onchain, Timelock};
 use crate::consensus::{self, Decodable, Encodable};
-use crate::crypto::{self, AccordantKeySet, Signatures};
+use crate::crypto::{self, AccordantKeySet};
 
 /// Possible roles during the negotiation phase. Any negotiation role can transition into any swap
 /// role when negotiation is completed, the transition is described in the public offer.

--- a/src/swap/btcxmr.rs
+++ b/src/swap/btcxmr.rs
@@ -9,7 +9,11 @@ use crate::crypto::{
     ProveCrossGroupDleq, SharedKeyId,
 };
 #[cfg(feature = "experimental")]
-use crate::{bitcoin::BitcoinSegwitV0, crypto::Sign, monero::Monero};
+use crate::{
+    bitcoin::BitcoinSegwitV0,
+    crypto::{EncSign, RecoverSecret, Sign},
+    monero::Monero,
+};
 use crate::{blockchain::Blockchain, crypto::dleq::DLEQProof};
 
 use monero::cryptonote::hash::Hash;
@@ -294,7 +298,7 @@ impl GenerateSharedKey<SecretKey> for KeyManager {
 
 #[cfg(feature = "experimental")]
 #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
-impl Sign<PublicKey, SecretKey, Sha256dHash, Signature, EncryptedSignature> for KeyManager {
+impl Sign<PublicKey, Sha256dHash, Signature> for KeyManager {
     fn sign(
         &mut self,
         key: ArbitratingKeyId,
@@ -325,7 +329,11 @@ impl Sign<PublicKey, SecretKey, Sha256dHash, Signature, EncryptedSignature> for 
         secp.verify_ecdsa(&message, sig, key)
             .map_err(crypto::Error::new)
     }
+}
 
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+impl EncSign<PublicKey, Sha256dHash, Signature, EncryptedSignature> for KeyManager {
     fn encrypt_sign(
         &mut self,
         signing_key: ArbitratingKeyId,
@@ -390,7 +398,11 @@ impl Sign<PublicKey, SecretKey, Sha256dHash, Signature, EncryptedSignature> for 
 
         Ok(adaptor.decrypt_signature(&decryption_key, sig).into())
     }
+}
 
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+impl RecoverSecret<PublicKey, SecretKey, Signature, EncryptedSignature> for KeyManager {
     fn recover_secret_key(
         &self,
         encrypted_sig: EncryptedSignature,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -9,7 +9,6 @@ use thiserror::Error;
 
 use crate::blockchain::{Address, Asset, Fee, Network, Onchain, Timelock};
 use crate::consensus::{self, Decodable, Encodable};
-use crate::crypto::Signatures;
 use crate::script::{DataLock, DataPunishableLock, ScriptPath};
 
 /// A list specifying general categories of transaction error.

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -4,8 +4,8 @@ use std::convert::TryInto;
 use std::str::FromStr;
 
 use farcaster_core::crypto::{
-    AccordantKeyId, ArbitratingKeyId, GenerateKey, GenerateSharedKey, ProveCrossGroupDleq,
-    SharedKeyId, Sign,
+    AccordantKeyId, ArbitratingKeyId, EncSign, GenerateKey, GenerateSharedKey, ProveCrossGroupDleq,
+    RecoverSecret, SharedKeyId, Sign,
 };
 use farcaster_core::monero::SHARED_VIEW_KEY_ID;
 use farcaster_core::swap::btcxmr::*;


### PR DESCRIPTION
Based on #255
Diff starts at e287d1efee5ef0e2713d88de30ef74630a70f441.

Split the `Sign` trait to be more specific about requirements in `protocol` functions. Remove `Signatures` trait because it became useless after #255 refactor. Improve `Commit` trait.