### PR TITLE
fix: network conversions

### DIFF
--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -8,7 +8,7 @@ use bitcoin::util::psbt::PartiallySignedTransaction;
 use bitcoin::Address;
 use bitcoin::Amount;
 
-use crate::blockchain::{self, Asset, Onchain, Timelock};
+use crate::blockchain::{self, Asset, Network, Onchain, Timelock};
 
 pub(crate) mod address;
 pub(crate) mod amount;
@@ -100,4 +100,25 @@ impl<S: Strategy> Timelock for Bitcoin<S> {
 impl<S: Strategy> Onchain for Bitcoin<S> {
     type PartialTransaction = PartiallySignedTransaction;
     type Transaction = bitcoin::Transaction;
+}
+
+impl From<Network> for bitcoin::Network {
+    fn from(network: Network) -> Self {
+        match network {
+            Network::Mainnet => Self::Bitcoin,
+            Network::Testnet => Self::Testnet,
+            Network::Local => Self::Regtest,
+        }
+    }
+}
+
+impl From<bitcoin::Network> for Network {
+    fn from(network: bitcoin::Network) -> Self {
+        match network {
+            bitcoin::Network::Bitcoin => Self::Mainnet,
+            bitcoin::Network::Testnet => Self::Testnet,
+            bitcoin::Network::Signet => Self::Testnet,
+            bitcoin::Network::Regtest => Self::Local,
+        }
+    }
 }

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -428,29 +428,42 @@ impl FromStr for Network {
     }
 }
 
-impl From<bitcoin::Network> for Network {
-    fn from(btc_network: bitcoin::Network) -> Self {
-        match btc_network {
-            bitcoin::Network::Bitcoin => Self::Mainnet,
-            bitcoin::Network::Testnet => Self::Testnet,
-            bitcoin::Network::Signet => Self::Testnet,
-            bitcoin::Network::Regtest => Self::Local,
-        }
-    }
-}
-
 /// Defines a blockchain network, identifies in which context the system interacts with the
 /// blockchain.
+///
+/// When adding support for a new blockchain in the library a [`From`] implementation must be
+/// provided such that it is possible to know what blockchain network to use for each of the three
+/// generic contexts: `mainnet`, `testnet`, and `local`.
+///
+/// ```rust
+/// use farcaster_core::blockchain::Network;
+///
+/// pub enum MyNet {
+///     MyNet,
+///     Test,
+///     Regtest,
+/// }
+///
+/// impl From<Network> for MyNet {
+///     fn from(net: Network) -> Self {
+///         match net {
+///             Network::Mainnet => Self::MyNet,
+///             Network::Testnet => Self::Test,
+///             Network::Local => Self::Regtest,
+///         }
+///     }
+/// }
+/// ```
 #[derive(
     Copy, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Debug, Display, Serialize, Deserialize,
 )]
 #[display(Debug)]
 pub enum Network {
-    /// Represents a real asset on his valuable network.
+    /// Valuable, real, assets on its production network.
     Mainnet,
-    /// Represents non-valuable assets on test networks.
+    /// Non-valuable assets on its online test networks.
     Testnet,
-    /// Local and private testnets.
+    /// Non-valuable assets on offline test network.
     Local,
 }
 
@@ -499,11 +512,51 @@ mod tests {
     }
 
     #[test]
-    fn network_conversion() {
+    fn bitcoin_network_conversion() {
         assert_eq!(Network::from(bitcoin::Network::Bitcoin), Network::Mainnet);
         assert_eq!(Network::from(bitcoin::Network::Testnet), Network::Testnet);
         assert_eq!(Network::from(bitcoin::Network::Signet), Network::Testnet);
         assert_eq!(Network::from(bitcoin::Network::Regtest), Network::Local);
+        assert_eq!(
+            bitcoin::Network::from(Network::Mainnet),
+            bitcoin::Network::Bitcoin
+        );
+        assert_eq!(
+            Into::<bitcoin::Network>::into(Network::Mainnet),
+            bitcoin::Network::Bitcoin,
+        );
+        assert_eq!(
+            bitcoin::Network::from(Network::Testnet),
+            bitcoin::Network::Testnet
+        );
+        assert_eq!(
+            Into::<bitcoin::Network>::into(Network::Testnet),
+            bitcoin::Network::Testnet,
+        );
+        assert_eq!(
+            bitcoin::Network::from(Network::Local),
+            bitcoin::Network::Regtest
+        );
+        assert_eq!(
+            Into::<bitcoin::Network>::into(Network::Local),
+            bitcoin::Network::Regtest,
+        );
+    }
+
+    #[test]
+    fn monero_network_conversion() {
+        assert_eq!(
+            monero::Network::from(Network::Mainnet),
+            monero::Network::Mainnet
+        );
+        assert_eq!(
+            monero::Network::from(Network::Testnet),
+            monero::Network::Stagenet
+        );
+        assert_eq!(
+            monero::Network::from(Network::Local),
+            monero::Network::Mainnet
+        );
     }
 
     #[test]

--- a/src/monero.rs
+++ b/src/monero.rs
@@ -62,9 +62,19 @@ impl Accordant<PublicKey, PrivateKey, Address> for Monero {
 impl From<Network> for monero::Network {
     fn from(network: Network) -> Self {
         match network {
-            Network::Mainnet => monero::Network::Mainnet,
-            Network::Testnet => monero::Network::Stagenet,
-            Network::Local => monero::Network::Mainnet,
+            Network::Mainnet => Self::Mainnet,
+            Network::Testnet => Self::Stagenet,
+            Network::Local => Self::Mainnet,
+        }
+    }
+}
+
+impl From<monero::Network> for Network {
+    fn from(network: monero::Network) -> Self {
+        match network {
+            monero::Network::Mainnet => Self::Mainnet,
+            monero::Network::Stagenet => Self::Testnet,
+            monero::Network::Testnet => Self::Testnet,
         }
     }
 }


### PR DESCRIPTION
Fix #248

When reviewing #247 I missed the conversion flow, it should be `blockchain::Network` -> `btc|xmr::Network` and not the inverse. And the issue was not describing the problem correctly, sorry for that.