### PR TITLE
chore: use crates.io secpfun, use bytes to convert types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,11 +46,11 @@ tiny-keccak = { version = "2", features = ["keccak"] }
 
 bincode = { version = "1", optional = true }
 curve25519-dalek = { version = "3", features = ["serde"] }
-ecdsa_fun = { git = "https://github.com/farcaster-project/secp256kfun.git", branch = "secp256k1/0.22", default-features = false, features = ["all"], optional = true }
+ecdsa_fun = { version = "0.7", default-features = false, features = ["all"], optional = true }
 rand = { version = "0.8.4", optional = true }
 rand_alt = { package = "rand", version = "0.7.3", features = ["std"] }
 rand_chacha = { version = "0.3.1", optional = true }
-secp256kfun = { git = "https://github.com/farcaster-project/secp256kfun.git", branch = "secp256k1/0.22", default-features = false, features = ["std", "serde", "libsecp_compat"], optional = true }
+secp256kfun = { version = "0.7", default-features = false, features = ["std", "serde", "libsecp_compat"], optional = true }
 sha2 = { version = "0.9", optional = true }
 sha3 = "0.10"
 


### PR DESCRIPTION
Fix #246

Temporary usage of bytes to convert between `secp256k1` and `*fun` libs, waiting next release to synchronize `secp256k1` again. See #268.