### PR TITLE
chore: license headers and dprint update

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -7,7 +7,7 @@
   "includes": ["**/*.{md,toml}"],
   "excludes": ["target"],
   "plugins": [
-    "https://plugins.dprint.dev/markdown-0.11.0.wasm",
-    "https://plugins.dprint.dev/toml-0.5.2.wasm"
+    "https://plugins.dprint.dev/markdown-0.13.3.wasm",
+    "https://plugins.dprint.dev/toml-0.5.4.wasm"
   ]
 }

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Implementation for the Bitcoin blockchain as an arbitrating blockchain in a swap, with multiple
 //! strategies (ECDSA, Taproot, Taproot+MuSig2).
 

--- a/src/bitcoin/address.rs
+++ b/src/bitcoin/address.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 use crate::consensus::{self, CanonicalBytes};
 use bitcoin::Address;
 

--- a/src/bitcoin/amount.rs
+++ b/src/bitcoin/amount.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 use crate::consensus::{self, CanonicalBytes};
 use bitcoin::Amount;
 

--- a/src/bitcoin/fee.rs
+++ b/src/bitcoin/fee.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Transaction fee unit type and implementation. Defines the [`SatPerVByte`] unit used in methods
 //! that set the fee and check the fee on transactions given a [`FeeStrategy`] and a
 //! [`FeePriority`].

--- a/src/bitcoin/segwitv0.rs
+++ b/src/bitcoin/segwitv0.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! SegWit version 0 implementation for Bitcoin. Inner implementation of [`BitcoinSegwitV0`].
 
 use std::convert::TryFrom;

--- a/src/bitcoin/segwitv0/buy.rs
+++ b/src/bitcoin/segwitv0/buy.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 use std::marker::PhantomData;
 
 use bitcoin::blockdata::transaction::{TxIn, TxOut};

--- a/src/bitcoin/segwitv0/cancel.rs
+++ b/src/bitcoin/segwitv0/cancel.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 use std::marker::PhantomData;
 
 use bitcoin::blockdata::transaction::{TxIn, TxOut};

--- a/src/bitcoin/segwitv0/funding.rs
+++ b/src/bitcoin/segwitv0/funding.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Implementation for handeling the funding transaction on-chain.
 
 use bitcoin::blockdata::transaction::{OutPoint, Transaction};

--- a/src/bitcoin/segwitv0/lock.rs
+++ b/src/bitcoin/segwitv0/lock.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 use std::marker::PhantomData;
 
 use bitcoin::blockdata::transaction::{TxIn, TxOut};

--- a/src/bitcoin/segwitv0/punish.rs
+++ b/src/bitcoin/segwitv0/punish.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 use std::marker::PhantomData;
 
 use bitcoin::blockdata::transaction::{TxIn, TxOut};

--- a/src/bitcoin/segwitv0/refund.rs
+++ b/src/bitcoin/segwitv0/refund.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 use std::marker::PhantomData;
 
 use bitcoin::blockdata::transaction::{TxIn, TxOut};

--- a/src/bitcoin/taproot/mod.rs
+++ b/src/bitcoin/taproot/mod.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Implementation of a Taproot strategy with on-chain scripts for the arbitrating blockchain
 //! as Bitcoin. Inner implementation of [`BitcoinTaproot`].
 

--- a/src/bitcoin/timelock.rs
+++ b/src/bitcoin/timelock.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Timelock unit and `OP_CODE` to use in Bitcoin transactions and scripts.
 
 use crate::consensus::{self, CanonicalBytes};

--- a/src/bitcoin/transaction.rs
+++ b/src/bitcoin/transaction.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Bitcoin transactions framework. This module contains types shared across strategies.
 
 use std::fmt::Debug;

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Defines types used to characterize a swap and behaviours a blockchain must implement to
 //! participate in a swap, either as an arbitrating or an accordant blockchain.
 //!

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Farcaster consensus encoding used to strictly encode and decode data such as public offers,
 //! bundles or other messages defined in the RFCs.
 //!

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Cryptographic types (keys, signatures, commitments, etc) and traits (commit, generate key,
 //! sign, etc) used to create the generic framework for supporting multiple blockchains under the
 //! same interface.

--- a/src/crypto/dleq.rs
+++ b/src/crypto/dleq.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Discrete Logarithm Equality Proof system across the different groups secp256k1 and curve25519.
 
 use std::convert::TryInto;

--- a/src/crypto/slip10.rs
+++ b/src/crypto/slip10.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! SLIP-10 implementation for secp256k1 and ed25519. This implementation does not support NIST
 //! P-256 curve.
 //!

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 use std::fmt;
 
 use serde::de::{self, Unexpected, Visitor};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //!  ⚠️ **This library is a 🚧 work in progress 🚧 and does not implement everything yet, nor is
 //!  suitable for production use.**
 //!

--- a/src/monero.rs
+++ b/src/monero.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Implementation of the Monero blockchain as an accordant blockchain in a swap. This
 //! implementation should work in pair with any other arbitrating implementation, like Bitcoin.
 

--- a/src/negotiation.rs
+++ b/src/negotiation.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Negotiation helpers and structures. Buyer and seller helpers to create offer and public offers
 //! allowing agreement on assets, quantities and parameters of a swap among maker and taker.
 //!

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Protocol execution and messages exchanged between peers.
 
 // For this file we allow having complex types

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Protocol messages exchanged between swap daemons at each step of the swap protocol. These
 //! messages are untrusted and must be validated uppon reception by each swap participant.
 

--- a/src/role.rs
+++ b/src/role.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Roles used to distinguish participants and blockchains during negotiation and swap phases.
 //! Defines the trading roles and swap roles distributed among participants and blockchain roles
 //! implemented on Bitcoin, Monero, etc.

--- a/src/script.rs
+++ b/src/script.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Data structures used in scripts to create the arbitration engine on a blockchain.
 
 use std::fmt;

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Defines the high level of a swap between a Arbitrating blockchain and a Accordant blockchain
 //! and its concrete instances of swaps.
 

--- a/src/swap/btcxmr.rs
+++ b/src/swap/btcxmr.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Concrete implementation of a swap between Bitcoin as the arbitrating blockchain and Monero as the
 //! accordant blockchain.
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 //! Arbitrating transaction traits used as the on-chain arbitration engine on the arbitrating
 //! blockchain. These traits define the steps allowed in the arbitration engine enforced on-chain.
 

--- a/tests/negotiation.rs
+++ b/tests/negotiation.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 use farcaster_core::bitcoin::fee::SatPerVByte;
 use farcaster_core::bitcoin::timelock::CSVTimelock;
 use farcaster_core::blockchain::Blockchain;

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 use farcaster_core::bitcoin::segwitv0::{BuyTx, CancelTx, FundingTx, LockTx, PunishTx, RefundTx};
 use farcaster_core::bitcoin::BitcoinSegwitV0 as Btc;
 use farcaster_core::monero::Monero as Xmr;

--- a/tests/rpc/mod.rs
+++ b/tests/rpc/mod.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 use bitcoincore_rpc::{Auth, Client};
 use std::env;
 use std::path::PathBuf;

--- a/tests/transactions.rs
+++ b/tests/transactions.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 #![cfg(feature = "rpc")]
 
 use farcaster_core::bitcoin::fee::SatPerVByte;

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -1,3 +1,19 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
 use bitcoin::hashes::{sha256d, Hash};
 use rand::prelude::*;
 use std::convert::TryInto;


### PR DESCRIPTION
Adds LGPLv3 license headers in the codebase, update dprint plugins (checks toml and markdown formatting).