### PR TITLE
feat: more type definition for btc/xmr swap

### DIFF
--- a/src/swap/btcxmr.rs
+++ b/src/swap/btcxmr.rs
@@ -50,15 +50,17 @@ use secp256kfun::marker::*;
 #[cfg(feature = "experimental")]
 use sha2::Sha256;
 
+use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+use bitcoin::util::psbt::PartiallySignedTransaction;
 #[cfg(feature = "experimental")]
 use bitcoin::{
     hashes::sha256d::Hash as Sha256dHash, secp256k1::ecdsa::Signature, secp256k1::Message,
 };
 
-use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
-
 use std::collections::HashMap;
 use std::str::FromStr;
+
+pub mod message;
 
 #[cfg(feature = "experimental")]
 type Transcript = HashTranscript<Sha256, ChaCha20Rng>;
@@ -90,6 +92,16 @@ pub type Offer = negotiation::Offer<bitcoin::Amount, monero::Amount, CSVTimelock
 /// Fully defined type for Bitcoin-Monero atomic swap Bob public offer.
 pub type PublicOffer =
     negotiation::PublicOffer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>;
+
+pub type ArbitratingParameters =
+    protocol::ArbitratingParameters<bitcoin::Amount, CSVTimelock, SatPerVByte>;
+
+pub type CoreArbitratingTransactions =
+    protocol::CoreArbitratingTransactions<PartiallySignedTransaction>;
+
+pub type FullySignedPunish = protocol::FullySignedPunish<PartiallySignedTransaction, Signature>;
+
+pub type TxSignatures = protocol::TxSignatures<Signature>;
 
 /// Index, used as hardened derivation, to derive standard keys defined in the protocol for Bitcoin
 /// and Monero.

--- a/src/swap/btcxmr/message.rs
+++ b/src/swap/btcxmr/message.rs
@@ -1,0 +1,54 @@
+// Copyright 2021-2022 Farcaster Devs
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
+use crate::crypto::dleq::DLEQProof;
+use crate::crypto::KeccakCommitment;
+use crate::protocol::message;
+
+use bitcoin::secp256k1::ecdsa::Signature;
+use bitcoin::secp256k1::{PublicKey, SecretKey};
+use bitcoin::util::psbt::PartiallySignedTransaction;
+use bitcoin::Address;
+use ecdsa_fun::adaptor::EncryptedSignature;
+
+pub type BuyProcedureSignature =
+    message::BuyProcedureSignature<PartiallySignedTransaction, EncryptedSignature>;
+
+pub type CommitAliceParameters = message::CommitAliceParameters<KeccakCommitment>;
+pub type CommitBobParameters = message::CommitBobParameters<KeccakCommitment>;
+
+pub type CoreArbitratingSetup =
+    message::CoreArbitratingSetup<PartiallySignedTransaction, Signature>;
+
+pub type RefundProcedureSignatures =
+    message::RefundProcedureSignatures<Signature, EncryptedSignature>;
+
+pub type RevealAliceParameters = message::RevealAliceParameters<
+    PublicKey,
+    monero::PublicKey,
+    SecretKey,
+    monero::PrivateKey,
+    Address,
+>;
+pub type RevealBobParameters = message::RevealBobParameters<
+    PublicKey,
+    monero::PublicKey,
+    SecretKey,
+    monero::PrivateKey,
+    Address,
+>;
+
+pub type RevealProof = message::RevealProof<DLEQProof>;


### PR DESCRIPTION
Add all protocol message under `btcxmr::message` module and other protocol types.