### PR TITLE
chore: update rust edition 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump dependencies
 - Bump MSRV (Minimum Supported Rust Version) from 1.54.0 to 1.57.0
 - Bump bitvec to version 1
+- Move to Rust edition 2021
 
 ## [0.4.4] - 2022-02-27
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 repository = "https://github.com/farcaster-project/farcaster-core"
 description = "Farcaster project core library, blockchain atomic swaps."
 
-edition = "2018"
+edition = "2021"
 rust-version = "1.57.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Codebase seems to be already compatible with Rust edition 2021.