### PR TITLE
Deps: Bump internet-2 and microservices to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,10 @@ bitcoin_hashes = { version = "0.10" }
 bitvec = { version = "1.0" }
 fixed-hash = { version = "0.7", default-features = false }
 hex = "0.4"
-inet2_addr = { version = "0.6", default-features = false, features = ["tor", "strict_encoding"] }
+inet2_addr = { version = "0.8", default-features = false, features = ["tor", "strict_encoding"] }
 lightning_encoding = "0.6"
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
-strict_encoding = "1.8"
+strict_encoding = "0.8.0"
 strict_encoding_derive = "1.7"
 thiserror = "1"
 tiny-keccak = { version = "2", features = ["keccak"] }

--- a/src/negotiation.rs
+++ b/src/negotiation.rs
@@ -627,7 +627,7 @@ where
             strict_encoding::StrictEncode::strict_encode(&self.peer_address, s).map_err(|_| {
                 io::Error::new(
                     io::ErrorKind::InvalidData,
-                    "Failed to encode RemoteNodeAddr",
+                    "Failed to encode InetSocketAddr",
                 )
             })?;
         Ok(len)


### PR DESCRIPTION
Only opening for visibility, since this is what https://github.com/farcaster-project/farcaster-node/pull/589 is based on.