### PR TITLE
ci: bump ci shared workflows to 1.2.0

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,11 +9,11 @@ jobs:
   create_release:
     name: Create from merged release branch
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
-    uses: farcaster-project/workflows/.github/workflows/create-release.yml@v1.0.2
+    uses: farcaster-project/workflows/.github/workflows/create-release.yml@v1.2.0
 
   release_to_crates:
     name: Publish the new release to crates.io
-    uses: farcaster-project/workflows/.github/workflows/release-to-crates-io.yml@v1.0.2
+    uses: farcaster-project/workflows/.github/workflows/release-to-crates-io.yml@v1.2.0
     # Do not run before creating the release is done
     needs: create_release
     secrets:

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   draft-new-release:
-    name: "Draft a new release"
-    uses: farcaster-project/workflows/.github/workflows/draft-new-release.yml@v1.0.2
+    name: Draft a new release
+    uses: farcaster-project/workflows/.github/workflows/draft-new-release.yml@v1.2.0
     with:
       version: ${{ github.event.inputs.version }}

--- a/.github/workflows/release-to-crates-io.yml
+++ b/.github/workflows/release-to-crates-io.yml
@@ -8,6 +8,6 @@ on:
 jobs:
   release_to_crates:
     name: Publish the new release to crates.io
-    uses: farcaster-project/workflows/.github/workflows/release-to-crates-io.yml@v1.0.2
+    uses: farcaster-project/workflows/.github/workflows/release-to-crates-io.yml@v1.2.0
     secrets:
       cratesio_token: ${{ secrets.H4SH3D_CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Update shared workflows, this should not change previous functionalities, but uses up-to-date GH Actions.