### PR TITLE
fix: nightly compilation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,11 @@ jobs:
             stable,
             nightly
         ]
+        include:
+        - rust: nightly
+          features: default
+        - rust: nightly
+          features: default,nightly
 
     runs-on: ubuntu-latest
 
@@ -34,7 +39,7 @@ jobs:
 
     - uses: Swatinem/rust-cache@v2.0.0
 
-    - run: cargo test --verbose
+    - run: cargo test --verbose --features ${{ matrix.features }}
 
   rpc-test:
     name: Integration tests
@@ -44,6 +49,11 @@ jobs:
             stable,
             nightly
         ]
+        include:
+        - rust: nightly
+          features: default,rpc
+        - rust: nightly
+          features: default,rpc,nightly
 
     runs-on: ubuntu-latest
     container:
@@ -74,7 +84,7 @@ jobs:
         profile: minimal
 
     - name: Run regtest Bitcoin transactions
-      run: cargo test --verbose --test transactions --features rpc -- --test-threads=1
+      run: cargo test --verbose --test transactions --features ${{ matrix.features }} -- --test-threads=1
       env:
         RPC_HOST: bitcoind
         RPC_PORT: 18443

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
             nightly
         ]
         include:
-        - rust: nightly
+        - rust: stable
           features: default
         - rust: nightly
           features: default,nightly
@@ -50,7 +50,7 @@ jobs:
             nightly
         ]
         include:
-        - rust: nightly
+        - rust: stable
           features: default,rpc
         - rust: nightly
           features: default,rpc,nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rust-version = "1.59.0"
 rpc = []
 experimental = ["ecdsa_fun", "secp256kfun", "rand", "sha2", "rand_chacha", "bincode"]
 taproot = []
+nightly = []
 
 default = ["experimental", "taproot"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@
 //! method.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(feature = "nightly", feature(stmt_expr_attributes))]
 // Coding conventions
 #![forbid(unsafe_code)]
 #![deny(non_upper_case_globals)]


### PR DESCRIPTION
Introduce nightly feature to enable stmt_expr_attributes that fix nightly compilation

It sucks because the `Cargo.toml` got worst and it will also pollute node when released.

**When using nightly to compile the crate you must enable the `nightly` feature**