### PR TITLE
refactor: move to trade terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Module `negotiation` is renamed `trade`
+- `Offer` and `PublicOffer` are renamed `Trade` and `PublicTrade`, these structs are used to initialized a swap and should be the outcome of a proper negotiation phase
+
 ### Removed
 
 - `lightning_encoding` is removed for the protocol messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Module `negotiation` is renamed `trade`
-- `Offer` and `PublicOffer` are renamed `DealParameters` and `Deal`, these structs are used to initialized a swap and should be the outcome of a proper negotiation phase
+- Module `negotiation` is renamed as the `trade` module
+- `Offer` and `PublicOffer` are renamed `DealParameters` and `Deal`, these structs are used to initialized a swap during the trade setup and should be the outcome of a proper negotiation phase currently out-of-scope for this library
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Module `negotiation` is renamed `trade`
-- `Offer` and `PublicOffer` are renamed `Trade` and `PublicTrade`, these structs are used to initialized a swap and should be the outcome of a proper negotiation phase
+- `Offer` and `PublicOffer` are renamed `DealParameters` and `Deal`, these structs are used to initialized a swap and should be the outcome of a proper negotiation phase
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 The Farcaster atomic swaps project core library aim to implement in Rust the following functionalities needed to build a swap node:
 
 - [x] Swap deals (contains all necessary information to start a swap)
-- [x] Swap roles and trade roles (who do what during the swap)
+- [x] Swap roles and trade roles (who does what during the swap)
 - [x] Transaction templates implementing on-chain behaviours (arbitration engine, e.g. on Bitcoin blockchain)
 - [x] Signature and cryptographic utilities
   - [x] ECDSA adaptor signatures
@@ -24,7 +24,7 @@ Check out the documentation of this library on [docs.rs/farcaster_core](https://
 
 ## Core framework
 
-This library is twofold: providing a flexible framework to add specific blockchain support and implementing these specific blockchain (currently _bitcoin_ and _monero_). The framework is split in modules at the root of the crate:
+This library's purpose is twofold: providing a flexible framework to add specific blockchain support and implementing these specific blockchains (currently _bitcoin_ and _monero_). The framework is split in modules at the root of the crate:
 
 - `blockchain`: generic types and traits for declaring assets/chains and on-chain behavior.
 - `consensus`: encoding and decoding implementation for all types in the crate, used to serialize and deserialize messages exchanged.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 The Farcaster atomic swaps project core library aim to implement in Rust the following functionalities needed to build a swap node:
 
-- [x] Swap trades (contains all necessary information to start a trade)
-- [x] Swap roles and trade roles (who do what during the trade)
+- [x] Swap deals (contains all necessary information to start a swap)
+- [x] Swap roles and trade roles (who do what during the swap)
 - [x] Transaction templates implementing on-chain behaviours (arbitration engine, e.g. on Bitcoin blockchain)
 - [x] Signature and cryptographic utilities
   - [x] ECDSA adaptor signatures
@@ -29,7 +29,7 @@ This library is twofold: providing a flexible framework to add specific blockcha
 - `blockchain`: generic types and traits for declaring assets/chains and on-chain behavior.
 - `consensus`: encoding and decoding implementation for all types in the crate, used to serialize and deserialize messages exchanged.
 - `crypto`: traits and generic types to define cryptographic interactions (wallet capability, commit/reveal scheme, signature and key types, etc).
-- `trade`: generic types and utilities for handling the trade phase, e.g. creating a public trade.
+- `trade`: generic types and utilities for handling the trade setup, e.g. creating a deal.
 - `protocol`: generic types related to the execution of the protocol and messages exchanged between peers.
 - `role`: role definitions (trade and swap) and trait for the generic framework.
 - `script`: generic types for transaction data management.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 The Farcaster atomic swaps project core library aim to implement in Rust the following functionalities needed to build a swap node:
 
-- [x] Swap offers (contains all necessary information to start a trade)
+- [x] Swap trades (contains all necessary information to start a trade)
 - [x] Swap roles and trade roles (who do what during the trade)
 - [x] Transaction templates implementing on-chain behaviours (arbitration engine, e.g. on Bitcoin blockchain)
 - [x] Signature and cryptographic utilities
@@ -29,7 +29,7 @@ This library is twofold: providing a flexible framework to add specific blockcha
 - `blockchain`: generic types and traits for declaring assets/chains and on-chain behavior.
 - `consensus`: encoding and decoding implementation for all types in the crate, used to serialize and deserialize messages exchanged.
 - `crypto`: traits and generic types to define cryptographic interactions (wallet capability, commit/reveal scheme, signature and key types, etc).
-- `negotiation`: generic types and utilities for handling the negotiation phase, e.g. creating a public offer.
+- `trade`: generic types and utilities for handling the trade phase, e.g. creating a public trade.
 - `protocol`: generic types related to the execution of the protocol and messages exchanged between peers.
 - `role`: role definitions (trade and swap) and trait for the generic framework.
 - `script`: generic types for transaction data management.

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -383,7 +383,7 @@ impl FromStr for FeePriority {
 /// in fee strategies and an amount used in transactions. Implementing this trait allow to set and
 /// verify fees on transactions given a strategy and a priority.
 ///
-/// The fee to apply on transactions is carried in the [`Offer`](crate::negotiation::Offer) through
+/// The fee to apply on transactions is carried in the [`Offer`](crate::trade::Offer) through
 /// a [`FeeStrategy`], in case the fee strategy allow multiple values a [`FeePriority`] is used to
 /// fix the amount.
 ///

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -383,8 +383,8 @@ impl FromStr for FeePriority {
 /// in fee strategies and an amount used in transactions. Implementing this trait allow to set and
 /// verify fees on transactions given a strategy and a priority.
 ///
-/// The fee to apply on transactions is carried in the [`Trade`](crate::trade::Trade) through
-/// a [`FeeStrategy`], in case the fee strategy allow multiple values a [`FeePriority`] is used to
+/// The fee to apply on transactions is carried in the [`Deal`](crate::trade::Deal) through a
+/// [`FeeStrategy`], in case the fee strategy allow multiple values a [`FeePriority`] is used to
 /// fix the amount.
 ///
 /// ```

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -169,7 +169,7 @@ pub trait Transactions {
 /// a fee strategy can be: fixed or range. When the fee strategy allows multiple possibilities, a
 /// [`FeePriority`] is used to determine what to apply.
 ///
-/// A fee strategy is included in an offer, so Alice and Bob can verify that transactions are valid
+/// A fee strategy is included in a deal, so Alice and Bob can verify that transactions are valid
 /// upon reception by the other participant.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum FeeStrategy<T> {

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -383,7 +383,7 @@ impl FromStr for FeePriority {
 /// in fee strategies and an amount used in transactions. Implementing this trait allow to set and
 /// verify fees on transactions given a strategy and a priority.
 ///
-/// The fee to apply on transactions is carried in the [`Offer`](crate::trade::Offer) through
+/// The fee to apply on transactions is carried in the [`Trade`](crate::trade::Trade) through
 /// a [`FeeStrategy`], in case the fee strategy allow multiple values a [`FeePriority`] is used to
 /// fix the amount.
 ///

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
-//! Farcaster consensus encoding used to strictly encode and decode data such as a deal, a data
-//! structure exchanged among swap participants during the swap setup.
+//! Farcaster consensus encoding used to strictly encode and decode data such as a deal: a data
+//! structure exchanged between swap participants during their swap setup.
 //!
 //! Implementation on blockchain foreign types with [`CanonicalBytes`] must follow the strict
 //! consensus encoding from the blockchain itself, Farcaster core will then wrap the serialization

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -15,7 +15,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
 //! Farcaster consensus encoding used to strictly encode and decode data such as a deal: a data
-//! structure exchanged between swap participants during their swap setup.
+//! structure exchanged between swap participants during their trade setup.
 //!
 //! Implementation on blockchain foreign types with [`CanonicalBytes`] must follow the strict
 //! consensus encoding from the blockchain itself, Farcaster core will then wrap the serialization

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -14,7 +14,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
-//! Farcaster consensus encoding used to strictly encode and decode data such as public offers,
+//! Farcaster consensus encoding used to strictly encode and decode data such as public trades,
 //! bundles or other messages defined in the RFCs.
 //!
 //! Implementation on blockchain foreign types with [`CanonicalBytes`] must follow the strict

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
-//! Farcaster consensus encoding used to strictly encode and decode data such as public trades,
-//! bundles or other messages defined in the RFCs.
+//! Farcaster consensus encoding used to strictly encode and decode data such as a deal, a data
+//! structure exchanged among swap participants during the swap setup.
 //!
 //! Implementation on blockchain foreign types with [`CanonicalBytes`] must follow the strict
 //! consensus encoding from the blockchain itself, Farcaster core will then wrap the serialization

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -344,9 +344,6 @@ impl Commit<KeccakCommitment> for CommitmentEngine {
 ///     }
 /// }
 /// ```
-///
-/// [`Arbitrating`]: crate::role::Arbitrating
-/// [`Accordant`]: crate::role::Accordant
 pub trait DeriveKeys {
     type PublicKey;
     type PrivateKey;

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -43,28 +43,3 @@ impl<'de> Visitor<'de> for HashString {
         }
     }
 }
-
-/// A visitor that deserializes a public offer
-pub(crate) struct OfferString;
-
-impl<'de> Visitor<'de> for OfferString {
-    type Value = String;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            formatter,
-            "a string representing a public offer in Base58 value"
-        )
-    }
-
-    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        if s.len() == 195 {
-            Ok(s.to_string())
-        } else {
-            Err(de::Error::invalid_length(s.len(), &self))
-        }
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@
 //! Farcaster core library aims to implement in Rust the core principles described in Farcaster
 //! [RFCs](https://github.com/farcaster-project/RFCs):
 //!
-//! - Swap deals, data needed to start a swap with a counter-party
-//! - Swap roles and trade roles, who do what in the protocol
+//! - Swap deals: data needed to start a swap with a counter-party
+//! - Swap roles and trade roles: who does what in the protocol
 //! - Transaction templates implementing on-chain behaviours
 //! - Signature and cryptographic utilities
 //!   - ECDSA adaptor signatures

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,11 +82,11 @@ pub mod blockchain;
 pub mod crypto;
 pub(crate) mod hash;
 pub mod monero;
-pub mod trade;
 pub mod protocol;
 pub mod role;
 pub mod script;
 pub mod swap;
+pub mod trade;
 pub mod transaction;
 
 /// A list of possible errors when performing a cross-chain atomic swap with the **Farcaster**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! Farcaster core library aims to implement in Rust the core principles described in Farcaster
 //! [RFCs](https://github.com/farcaster-project/RFCs):
 //!
-//! - Swap offers, data needed to start a swap with a counter-party
+//! - Swap trades, data needed to start a swap with a counter-party
 //! - Swap roles and trade roles, who do what in the protocol
 //! - Transaction templates implementing on-chain behaviours
 //! - Signature and cryptographic utilities

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! Farcaster core library aims to implement in Rust the core principles described in Farcaster
 //! [RFCs](https://github.com/farcaster-project/RFCs):
 //!
-//! - Swap trades, data needed to start a swap with a counter-party
+//! - Swap deals, data needed to start a swap with a counter-party
 //! - Swap roles and trade roles, who do what in the protocol
 //! - Transaction templates implementing on-chain behaviours
 //! - Signature and cryptographic utilities

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ pub mod blockchain;
 pub mod crypto;
 pub(crate) mod hash;
 pub mod monero;
-pub mod negotiation;
+pub mod trade;
 pub mod protocol;
 pub mod role;
 pub mod script;
@@ -107,9 +107,9 @@ pub enum Error {
     /// An arbitrating transaction error.
     #[error("Transaction error: {0}")]
     Transaction(#[from] transaction::Error),
-    /// A negotiation error.
-    #[error("Negotiation error: {0}")]
-    Negotiation(#[from] negotiation::Error),
+    /// A trade error.
+    #[error("Trade error: {0}")]
+    Trade(#[from] trade::Error),
 }
 
 /// Result of an high level computation such as in Alice and Bob roles executing the protocol,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -35,7 +35,7 @@ use crate::protocol::message::{
 };
 use crate::script::{DataLock, DataPunishableLock, DoubleKeys, ScriptPath};
 use crate::swap::SwapId;
-use crate::trade::PublicTrade;
+use crate::trade::Deal;
 use crate::transaction::{
     Buyable, Cancelable, Chainable, Fundable, Lockable, Punishable, Refundable, Transaction,
     Witnessable,
@@ -428,7 +428,7 @@ where
     pub fn generate_parameters<Kg, Amt, Bmt, Ti, F, Pk, Qk, Rk, Sk, Pr>(
         &self,
         key_gen: &mut Kg,
-        public_trade: &PublicTrade<Amt, Bmt, Ti, F>,
+        deal: &Deal<Amt, Bmt, Ti, F>,
     ) -> Res<Parameters<Pk, Qk, Rk, Sk, Addr, Ti, F, Pr>>
     where
         Ar: DeriveKeys<PublicKey = Pk, PrivateKey = Rk>,
@@ -484,9 +484,9 @@ where
             accordant_shared_keys: accordant_shared_keys?,
             proof: Some(proof),
             destination_address: self.destination_address.clone(),
-            cancel_timelock: Some(public_trade.trade.cancel_timelock),
-            punish_timelock: Some(public_trade.trade.punish_timelock),
-            fee_strategy: Some(public_trade.trade.fee_strategy),
+            cancel_timelock: Some(deal.parameters.cancel_timelock),
+            punish_timelock: Some(deal.parameters.punish_timelock),
+            fee_strategy: Some(deal.parameters.fee_strategy),
         })
     }
 
@@ -1067,7 +1067,7 @@ where
     pub fn generate_parameters<Amt, Bmt, Pk, Qk, Rk, Sk, Ti, F, Pr, Kg>(
         &self,
         key_gen: &mut Kg,
-        public_trade: &PublicTrade<Amt, Bmt, Ti, F>,
+        deal: &Deal<Amt, Bmt, Ti, F>,
     ) -> Res<Parameters<Pk, Qk, Rk, Sk, Addr, Ti, F, Pr>>
     where
         Ar: DeriveKeys<PublicKey = Pk, PrivateKey = Rk>,
@@ -1123,9 +1123,9 @@ where
             accordant_shared_keys: accordant_shared_keys?,
             proof: Some(proof),
             destination_address: self.refund_address.clone(),
-            cancel_timelock: Some(public_trade.trade.cancel_timelock),
-            punish_timelock: Some(public_trade.trade.punish_timelock),
-            fee_strategy: Some(public_trade.trade.fee_strategy.clone()),
+            cancel_timelock: Some(deal.parameters.cancel_timelock),
+            punish_timelock: Some(deal.parameters.punish_timelock),
+            fee_strategy: Some(deal.parameters.fee_strategy.clone()),
         })
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -29,7 +29,7 @@ use crate::crypto::{
     RecoverSecret, SharedKeyId, Sign, TaggedElement, TaggedElements, TaggedExtraKeys,
     TaggedSharedKeys,
 };
-use crate::negotiation::PublicOffer;
+use crate::trade::PublicOffer;
 use crate::protocol::message::{
     BuyProcedureSignature, CommitAliceParameters, CommitBobParameters, CoreArbitratingSetup,
     RevealAliceParameters, RevealBobParameters,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -423,7 +423,7 @@ where
     /// # Safety
     ///
     /// All the data passed to the function are considered trusted and does not require extra
-    /// validation. Thus we assume the public trade has been validated upfront.
+    /// validation. Thus we assume the deal has been validated upfront.
     ///
     pub fn generate_parameters<Kg, Amt, Bmt, Ti, F, Pk, Qk, Rk, Sk, Pr>(
         &self,
@@ -829,7 +829,7 @@ where
         let mut punish =
             <Ar::Punish>::initialize(&cancel, punish_lock, self.destination_address.clone())?;
 
-        // Set the fees according to the strategy in the trade and the local politic.
+        // Set the fees according to the strategy in the deal and the local politic.
         punish
             .as_partial_mut()
             .set_fee(fee_strategy, self.fee_politic)?;
@@ -872,7 +872,7 @@ where
     //
     //  * the transaction template is valid (transaction is well formed, contract and keys are used
     //  correctly)
-    //  * the target amount from the trade is correct (for the lock transaction)
+    //  * the target amount from the deal is correct (for the lock transaction)
     //  * the fee strategy validation passes
     //
     fn validate_core<Amt, Pk, Qk, Rk, Sk, Ti, F, Pr, Ms, Si, Px>(
@@ -914,7 +914,7 @@ where
 
         // Verify the lock transaction template.
         lock.verify_template(data_lock)?;
-        // The target amount is dictated from the public trade.
+        // The target amount is dictated from the deal.
         let target_amount = arb_params.arbitrating_amount;
         // Verify the target amount
         lock.verify_target_amount(target_amount)?;
@@ -1049,19 +1049,19 @@ impl<Addr, Ar, Ac> Bob<Addr, Ar, Ac>
 where
     Addr: Clone,
 {
-    /// Generate Bob's parameters for the protocol execution based on his seed and the public trade
-    /// agreed upon during the negotiation phase.
+    /// Generate Bob's parameters for the protocol execution based on his seed and the deal agreed
+    /// upon during the trade setup.
     ///
     /// # Safety
     ///
     /// All the data passed to the function are considered trusted and does not require extra
-    /// validation. The public trade is assumend to be validated by user upfront.
+    /// validation. The deal is assumend to be validated by user upfront.
     ///
     /// The parameters contain:
     ///
     ///  * The public keys used in the arbitrating and accordant blockchains
     ///  * The shared private keys (for reading opaque blockchains)
-    ///  * The timelock parameters from the public trade
+    ///  * The timelock parameters from the deal
     ///  * The target arbitrating address used by Bob
     ///
     pub fn generate_parameters<Amt, Bmt, Pk, Qk, Rk, Sk, Ti, F, Pr, Kg>(
@@ -1163,7 +1163,7 @@ where
     /// # Transaction Fee
     ///
     /// The fee on each transactions are set according to the [`FeeStrategy`] specified in the
-    /// public trade and the [`FeePriority`] in `self`.
+    /// deal and the [`FeePriority`] in `self`.
     ///
     /// [`FeeStrategy`]: crate::blockchain::FeeStrategy
     ///
@@ -1204,12 +1204,12 @@ where
             failure: DoubleKeys::new(alice_cancel, bob_cancel),
         };
 
-        // The target amount is dictated from the public trade.
+        // The target amount is dictated from the deal.
         let target_amount = arb_params.arbitrating_amount;
 
         // Initialize the lockable transaction based on the fundable structure. The lockable
         // transaction prepare the on-chain contract for a buy or a cancel. The amount of available
-        // assets is defined as the target by the public trade.
+        // assets is defined as the target by the deal.
         let lock = <Ar::Lock>::initialize(&funding, cancel_lock, target_amount)?;
 
         // Ensure that the transaction contains enough assets to pass the fee validation latter.
@@ -1235,7 +1235,7 @@ where
         // buy and moving them into a punisable on-chain contract.
         let mut cancel = <Ar::Cancel>::initialize(&lock, cancel_lock, punish_lock)?;
 
-        // Set the fees according to the strategy in the trade and the local politic.
+        // Set the fees according to the strategy in the deal and the local politic.
         cancel
             .as_partial_mut()
             .set_fee(fee_strategy, self.fee_politic)?;
@@ -1244,7 +1244,7 @@ where
         // the punishable lock to Bob's refund address.
         let mut refund = <Ar::Refund>::initialize(&cancel, self.refund_address.clone())?;
 
-        // Set the fees according to the strategy in the trade and the local politic.
+        // Set the fees according to the strategy in the deal and the local politic.
         refund
             .as_partial_mut()
             .set_fee(fee_strategy, self.fee_politic)?;
@@ -1388,7 +1388,7 @@ where
     /// # Execution
     ///
     ///  * Parse the [`Lockable`] partial transaction in [`CoreArbitratingTransactions`]
-    ///  * Generate the [`DataLock`] structure from Alice and Bob parameters and the public trade
+    ///  * Generate the [`DataLock`] structure from Alice and Bob parameters and the deal
     ///  * Retrieve Alice's adaptor public key from Alice's [`Parameters`]
     ///  * Retreive the buy public key from the paramters
     ///  * Generate the adaptor witness data and sign it
@@ -1447,7 +1447,7 @@ where
             alice_parameters.destination_address.clone(),
         )?;
 
-        // Set the fees according to the strategy in the trade and the local politic.
+        // Set the fees according to the strategy in the deal and the local politic.
         let fee_strategy = &arb_params.fee_strategy;
         buy.as_partial_mut()
             .set_fee(fee_strategy, self.fee_politic)?;

--- a/src/role.rs
+++ b/src/role.rs
@@ -26,14 +26,15 @@ use crate::blockchain::Network;
 use crate::consensus::{self, Decodable, Encodable};
 use crate::crypto::{self, AccordantKeySet};
 
-/// Possible roles during the trade setup. Any trade role can transition into any swap role when
-/// trade setup is completed, the transition is described in the deal.
+/// Possible roles during the trade setup. Trade roles are orthogonal to swap roles:
+/// any trade role can transition into any swap role, but the the particular transition
+/// that will happen is agreed upon & set in the deal.
 #[derive(Display, Debug, Clone, Hash, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[display(Debug)]
 pub enum TradeRole {
-    /// The maker role create the deal during the trade setup and waits for incoming connections.
+    /// The maker role creates the deal during the trade setup and waits for incoming connections.
     Maker,
-    /// The taker role parses deals and choose to connect to a maker node to start swapping.
+    /// The taker role parses deals and can choose to connect to a maker node to start swapping.
     Taker,
 }
 
@@ -80,7 +81,7 @@ impl FromStr for TradeRole {
     }
 }
 
-/// Possible roles during the swap phase. When trade setup is completed [`TradeRole`] will
+/// Possible roles during the swap phase. When the trade setup is completed [`TradeRole`] will
 /// transition into swap role according to the [`Deal`](crate::trade::Deal).
 #[derive(Display, Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[display(Debug)]

--- a/src/role.rs
+++ b/src/role.rs
@@ -27,14 +27,14 @@ use crate::consensus::{self, Decodable, Encodable};
 use crate::crypto::{self, AccordantKeySet};
 
 /// Possible roles during the trade phase. Any trade role can transition into any swap role when
-/// trade setup is completed, the transition is described in the public offer.
+/// trade setup is completed, the transition is described in the public trade.
 #[derive(Display, Debug, Clone, Hash, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[display(Debug)]
 pub enum TradeRole {
-    /// The maker role create the public offer during the trade phase and waits for incoming
+    /// The maker role create the public trade during the trade phase and waits for incoming
     /// connections.
     Maker,
-    /// The taker role parses public offers and choose to connect to a maker node to start
+    /// The taker role parses public trades and choose to connect to a maker node to start
     /// swapping.
     Taker,
 }
@@ -83,9 +83,9 @@ impl FromStr for TradeRole {
 }
 
 /// Possible roles during the swap phase. When trade phase is completed [`TradeRole`] will
-/// transition into swap role according to the [`PublicOffer`].
+/// transition into swap role according to the [`PublicTrade`].
 ///
-/// [`PublicOffer`]: crate::trade::PublicOffer
+/// [`PublicTrade`]: crate::trade::PublicTrade
 #[derive(Display, Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[display(Debug)]
 pub enum SwapRole {

--- a/src/role.rs
+++ b/src/role.rs
@@ -14,7 +14,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
-//! Roles used to distinguish participants and blockchains during trade and swap phases.
+//! Roles used to distinguish participants and blockchains during trade setup and swap phase.
 //! Defines the trading roles and swap roles distributed among participants and blockchain roles
 //! implemented on Bitcoin, Monero, etc.
 
@@ -26,21 +26,19 @@ use crate::blockchain::Network;
 use crate::consensus::{self, Decodable, Encodable};
 use crate::crypto::{self, AccordantKeySet};
 
-/// Possible roles during the trade phase. Any trade role can transition into any swap role when
-/// trade setup is completed, the transition is described in the public trade.
+/// Possible roles during the trade setup. Any trade role can transition into any swap role when
+/// trade setup is completed, the transition is described in the deal.
 #[derive(Display, Debug, Clone, Hash, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[display(Debug)]
 pub enum TradeRole {
-    /// The maker role create the public trade during the trade phase and waits for incoming
-    /// connections.
+    /// The maker role create the deal during the trade setup and waits for incoming connections.
     Maker,
-    /// The taker role parses public trades and choose to connect to a maker node to start
-    /// swapping.
+    /// The taker role parses deals and choose to connect to a maker node to start swapping.
     Taker,
 }
 
 impl TradeRole {
-    /// Return the other role possible in the trade phase.
+    /// Return the other role possible in the trade setup.
     pub fn other(&self) -> Self {
         match self {
             Self::Maker => Self::Taker,
@@ -82,7 +80,7 @@ impl FromStr for TradeRole {
     }
 }
 
-/// Possible roles during the swap phase. When trade phase is completed [`TradeRole`] will
+/// Possible roles during the swap phase. When trade setup is completed [`TradeRole`] will
 /// transition into swap role according to the [`Deal`](crate::trade::Deal).
 #[derive(Display, Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[display(Debug)]

--- a/src/role.rs
+++ b/src/role.rs
@@ -83,9 +83,7 @@ impl FromStr for TradeRole {
 }
 
 /// Possible roles during the swap phase. When trade phase is completed [`TradeRole`] will
-/// transition into swap role according to the [`PublicTrade`].
-///
-/// [`PublicTrade`]: crate::trade::PublicTrade
+/// transition into swap role according to the [`Deal`](crate::trade::Deal).
 #[derive(Display, Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[display(Debug)]
 pub enum SwapRole {

--- a/src/role.rs
+++ b/src/role.rs
@@ -14,7 +14,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
-//! Roles used to distinguish participants and blockchains during negotiation and swap phases.
+//! Roles used to distinguish participants and blockchains during trade and swap phases.
 //! Defines the trading roles and swap roles distributed among participants and blockchain roles
 //! implemented on Bitcoin, Monero, etc.
 
@@ -26,12 +26,12 @@ use crate::blockchain::Network;
 use crate::consensus::{self, Decodable, Encodable};
 use crate::crypto::{self, AccordantKeySet};
 
-/// Possible roles during the negotiation phase. Any negotiation role can transition into any swap
-/// role when negotiation is completed, the transition is described in the public offer.
+/// Possible roles during the trade phase. Any trade role can transition into any swap role when
+/// trade setup is completed, the transition is described in the public offer.
 #[derive(Display, Debug, Clone, Hash, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[display(Debug)]
 pub enum TradeRole {
-    /// The maker role create the public offer during the negotiation phase and waits for incoming
+    /// The maker role create the public offer during the trade phase and waits for incoming
     /// connections.
     Maker,
     /// The taker role parses public offers and choose to connect to a maker node to start
@@ -40,7 +40,7 @@ pub enum TradeRole {
 }
 
 impl TradeRole {
-    /// Return the other role possible in the negotiation phase.
+    /// Return the other role possible in the trade phase.
     pub fn other(&self) -> Self {
         match self {
             Self::Maker => Self::Taker,
@@ -82,10 +82,10 @@ impl FromStr for TradeRole {
     }
 }
 
-/// Possible roles during the swap phase. When negotitation phase is completed [`TradeRole`] will
+/// Possible roles during the swap phase. When trade phase is completed [`TradeRole`] will
 /// transition into swap role according to the [`PublicOffer`].
 ///
-/// [`PublicOffer`]: crate::negotiation::PublicOffer
+/// [`PublicOffer`]: crate::trade::PublicOffer
 #[derive(Display, Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[display(Debug)]
 pub enum SwapRole {

--- a/src/swap/btcxmr.rs
+++ b/src/swap/btcxmr.rs
@@ -85,11 +85,11 @@ pub type Alice = protocol::Alice<bitcoin::Address, BitcoinSegwitV0, Monero>;
 pub type Bob = protocol::Bob<bitcoin::Address, BitcoinSegwitV0, Monero>;
 
 /// Fully defined type for Bitcoin-Monero atomic swap trade.
-pub type Trade = trade::Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>;
+pub type DealParameters =
+    trade::DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>;
 
 /// Fully defined type for Bitcoin-Monero atomic swap public trade.
-pub type PublicTrade =
-    trade::PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>;
+pub type Deal = trade::Deal<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>;
 
 /// Fully defined type for Bitcoin-Monero atomic swap arbitrating parameters.
 pub type ArbitratingParameters =

--- a/src/swap/btcxmr.rs
+++ b/src/swap/btcxmr.rs
@@ -28,8 +28,8 @@ use crate::crypto::{
 #[cfg(feature = "experimental")]
 use crate::crypto::{EncSign, RecoverSecret, Sign};
 use crate::monero::Monero;
-use crate::trade;
 use crate::protocol;
+use crate::trade;
 use crate::{blockchain::Blockchain, crypto::dleq::DLEQProof};
 
 use monero::cryptonote::hash::Hash;
@@ -84,12 +84,12 @@ pub type Alice = protocol::Alice<bitcoin::Address, BitcoinSegwitV0, Monero>;
 /// Fully defined type for Bitcoin-Monero atomic swap Bob protocol role.
 pub type Bob = protocol::Bob<bitcoin::Address, BitcoinSegwitV0, Monero>;
 
-/// Fully defined type for Bitcoin-Monero atomic swap offer.
-pub type Offer = trade::Offer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>;
+/// Fully defined type for Bitcoin-Monero atomic swap trade.
+pub type Trade = trade::Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>;
 
-/// Fully defined type for Bitcoin-Monero atomic swap public offer.
-pub type PublicOffer =
-    trade::PublicOffer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>;
+/// Fully defined type for Bitcoin-Monero atomic swap public trade.
+pub type PublicTrade =
+    trade::PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>;
 
 /// Fully defined type for Bitcoin-Monero atomic swap arbitrating parameters.
 pub type ArbitratingParameters =

--- a/src/swap/btcxmr.rs
+++ b/src/swap/btcxmr.rs
@@ -28,7 +28,7 @@ use crate::crypto::{
 #[cfg(feature = "experimental")]
 use crate::crypto::{EncSign, RecoverSecret, Sign};
 use crate::monero::Monero;
-use crate::negotiation;
+use crate::trade;
 use crate::protocol;
 use crate::{blockchain::Blockchain, crypto::dleq::DLEQProof};
 
@@ -85,11 +85,11 @@ pub type Alice = protocol::Alice<bitcoin::Address, BitcoinSegwitV0, Monero>;
 pub type Bob = protocol::Bob<bitcoin::Address, BitcoinSegwitV0, Monero>;
 
 /// Fully defined type for Bitcoin-Monero atomic swap offer.
-pub type Offer = negotiation::Offer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>;
+pub type Offer = trade::Offer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>;
 
 /// Fully defined type for Bitcoin-Monero atomic swap public offer.
 pub type PublicOffer =
-    negotiation::PublicOffer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>;
+    trade::PublicOffer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>;
 
 /// Fully defined type for Bitcoin-Monero atomic swap arbitrating parameters.
 pub type ArbitratingParameters =

--- a/src/trade.rs
+++ b/src/trade.rs
@@ -27,7 +27,7 @@
 //! "Deal:" | base58(serialize(deal))
 //! ```
 //!
-//! The deals contains:
+//! The deal contains:
 //!
 //! - A version number, used for the version and potentially enabling features
 //! - The deal parameters, containing the asset types, amounts, timings, etc.
@@ -93,7 +93,7 @@ impl Decodable for Version {
     }
 }
 
-/// Errors used when manipulating deals parametes, deals and versions.
+/// Errors used when manipulating deals, deal parameters, and versions.
 #[derive(Error, Debug)]
 pub enum Error {
     /// The deal version is not supported.
@@ -105,7 +105,7 @@ pub enum Error {
 }
 
 fixed_hash::construct_fixed_hash!(
-    /// Identify a deal by it's content, internally store the hash of the deal serialized with
+    /// Identify a deal by its content, internally store the hash of the deal serialized with
     /// Farcaster consensus.
     pub struct DealFingerprint(32);
 );
@@ -129,7 +129,7 @@ impl<'de> Deserialize<'de> for DealFingerprint {
     }
 }
 
-/// Deal parameters is created by a [`TradeRole::Maker`] before the start of his daemon, it
+/// `DealParameters` is created by a [`TradeRole::Maker`] before the start of his daemon, it
 /// references all the data needed to parametrize a deal and be validated from a
 /// [`TradeRole::Taker`] perspective.  The daemon start when the maker is ready to finalize his
 /// deal, transforming the parameters into a [`Deal`] which contains the data needed to a taker to
@@ -261,7 +261,7 @@ where
     Self: Encodable,
 {
     /// Generate the [`DealFingerprint`] from the deal parameters. The fingerprint identifies the
-    /// content of a deal parameters (**without the uuid**) by taking the hash value of its
+    /// content of a deal's parameters (**without the uuid**) by taking the hash value of its
     /// serialization.
     pub fn fingerprint(&self) -> DealFingerprint {
         let mut keccak = Keccak::v256();

--- a/src/trade.rs
+++ b/src/trade.rs
@@ -14,24 +14,23 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
-//! Trade helpers and structures. Buyer and seller helpers to create trade and public trades
-//! allowing agreement on assets, quantities and parameters of a swap among maker and taker.
+//! Trade structures. Buyer and seller use deals to communicate parameters of a swap.
 //!
-//! ## Public Trade
+//! ## Deals
 //!
-//! A public trade is shared across the network by a maker. It contains all the data regarding what
-//! the trade is about (assets, amounts, timings, etc.).
+//! A deal is shared across the network by a maker. It contains all the data regarding what the
+//! deal is about (assets, amounts, timings, etc.) and where to connect to start the swap.
 //!
-//! A public trade is formatted like (base58 is Monero base58):
+//! A deal is formatted as (base58 is Monero base58):
 //!
 //! ```text
-//! "Trade:" | base58(serialize(public_trade))
+//! "Deal:" | base58(serialize(deal))
 //! ```
 //!
-//! The public trade contains:
+//! The deals contains:
 //!
 //! - A version number, used for the version and potentially enabling features
-//! - The trade, containing the asset types, amounts, timings, etc.
+//! - The deal parameters, containing the asset types, amounts, timings, etc.
 //! - A node identifier, used to secure the communication with the other peer
 //! - A peer address, used to connect to the other peer
 
@@ -54,24 +53,24 @@ use crate::hash::HashString;
 use crate::protocol::ArbitratingParameters;
 use crate::role::{SwapRole, TradeRole};
 
-/// First six magic bytes of a public trade. Bytes are included inside the base58 encoded part.
-pub const TRADE_MAGIC_BYTES: &[u8; 6] = b"FCSWAP";
+/// First six magic bytes of a deal. Bytes are included inside the base58 encoded part.
+pub const DEAL_MAGIC_BYTES: &[u8; 6] = b"FCSWAP";
 
-/// Prefix for serialized public trade.
-pub const PUB_TRADE_PREFIX: &str = "Trade:";
+/// Prefix for serialized deal.
+pub const DEAL_PREFIX: &str = "Deal:";
 
-/// A public trade version containing the version and the activated features if any.
+/// A deal version containing the version and the activated features if any.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Display, Serialize, Deserialize)]
 #[display("v{0}")]
 pub struct Version(u16);
 
 impl Version {
-    /// Create a new version 1 public trade.
+    /// Create a new version 1 deal.
     pub fn new_v1() -> Self {
         Self::new(1)
     }
 
-    /// Create a public trade from a raw version and feature `u16`.
+    /// Create a deal from a raw version and feature `u16`.
     pub fn new(version: u16) -> Self {
         Version(version)
     }
@@ -94,24 +93,24 @@ impl Decodable for Version {
     }
 }
 
-/// Trade errors used when manipulating trades, public trades and its version.
+/// Errors used when manipulating deals parametes, deals and versions.
 #[derive(Error, Debug)]
 pub enum Error {
-    /// The public trade version is not supported.
+    /// The deal version is not supported.
     #[error("Unsupported version")]
     UnsupportedVersion,
-    /// The public trade signature does not pass the validation tests.
+    /// The deal signature does not pass the validation tests.
     #[error("Invalid signature")]
     InvalidSignature,
 }
 
 fixed_hash::construct_fixed_hash!(
-    /// Identify an trade by it's content, internally store the hash of the trade serialized with
+    /// Identify a deal by it's content, internally store the hash of the deal serialized with
     /// Farcaster consensus.
-    pub struct TradeFingerprint(32);
+    pub struct DealFingerprint(32);
 );
 
-impl Serialize for TradeFingerprint {
+impl Serialize for DealFingerprint {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -120,31 +119,31 @@ impl Serialize for TradeFingerprint {
     }
 }
 
-impl<'de> Deserialize<'de> for TradeFingerprint {
-    fn deserialize<D>(deserializer: D) -> Result<TradeFingerprint, D::Error>
+impl<'de> Deserialize<'de> for DealFingerprint {
+    fn deserialize<D>(deserializer: D) -> Result<DealFingerprint, D::Error>
     where
         D: Deserializer<'de>,
     {
-        TradeFingerprint::from_str(&deserializer.deserialize_string(HashString)?)
+        DealFingerprint::from_str(&deserializer.deserialize_string(HashString)?)
             .map_err(de::Error::custom)
     }
 }
 
-/// An trade is created by a [`TradeRole::Maker`] before the start of his daemon, it references all
-/// the data needed to parametrize a trade and be validated from a [`TradeRole::Taker`]
-/// perspective. The daemon start when the maker is ready to finalize his trade, transforming the
-/// trade into a [`PublicTrade`] which contains the data needed to a taker to connect to the
-/// maker's daemon.
+/// Deal parameters is created by a [`TradeRole::Maker`] before the start of his daemon, it
+/// references all the data needed to parametrize a deal and be validated from a
+/// [`TradeRole::Taker`] perspective.  The daemon start when the maker is ready to finalize his
+/// deal, transforming the parameters into a [`Deal`] which contains the data needed to a taker to
+/// connect to the maker's daemon (address and identity).
 ///
 /// ## Serde implementation
 /// Amount types may have multiple serialization representation, e.g. btc and sat for bitcoin or
 /// xmr and pico for monero. Using [`Display`] and [`FromStr`] unifies the interface to
 /// de/serialize generic amounts.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct Trade<Amt, Bmt, Ti, F> {
-    /// The trade unique identifier.
+pub struct DealParameters<Amt, Bmt, Ti, F> {
+    /// The deal unique identifier.
     pub uuid: Uuid,
-    /// Type of trade and network to use.
+    /// Type of deal and network to use.
     pub network: Network,
     /// The chosen arbitrating blockchain.
     pub arbitrating_blockchain: Blockchain,
@@ -196,7 +195,7 @@ mod string {
     }
 }
 
-impl<Amt, Bmt, Ti, F> Display for Trade<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> Display for DealParameters<Amt, Bmt, Ti, F>
 where
     Self: Encodable,
     Amt: Display,
@@ -220,16 +219,12 @@ where
     }
 }
 
-impl<Amt, Bmt, Ti, F> Trade<Amt, Bmt, Ti, F> {
-    /// Transform the trade in a public trade of [`Version`] 1.
-    pub fn to_public_v1(
-        self,
-        node_id: PublicKey,
-        peer_address: InetSocketAddr,
-    ) -> PublicTrade<Amt, Bmt, Ti, F> {
-        PublicTrade {
+impl<Amt, Bmt, Ti, F> DealParameters<Amt, Bmt, Ti, F> {
+    /// Transform the deal parameters in a deal of [`Version`] 1.
+    pub fn to_v1(self, node_id: PublicKey, peer_address: InetSocketAddr) -> Deal<Amt, Bmt, Ti, F> {
+        Deal {
             version: Version::new_v1(),
-            trade: self,
+            parameters: self,
             node_id,
             peer_address,
         }
@@ -244,39 +239,40 @@ impl<Amt, Bmt, Ti, F> Trade<Amt, Bmt, Ti, F> {
     }
 }
 
-impl<Amt, Bmt, Ti, F> Trade<Amt, Bmt, Ti, F> {
-    /// Return the unique trade identifier. Same as [`Self::uuid()`].
+impl<Amt, Bmt, Ti, F> DealParameters<Amt, Bmt, Ti, F> {
+    /// Return the unique deal identifier. Same as [`Self::uuid()`].
     pub fn id(&self) -> Uuid {
         self.uuid()
     }
 
-    /// Return the unique trade identifier.
+    /// Return the unique deal identifier.
     pub fn uuid(&self) -> Uuid {
         self.uuid
     }
 
-    /// Reset trade's uuid with a new identifier.
+    /// Reset deal's uuid with a new identifier.
     pub fn randomize_uuid(&mut self) {
         self.uuid = Uuid::new_v4();
     }
 }
 
-impl<Amt, Bmt, Ti, F> Trade<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> DealParameters<Amt, Bmt, Ti, F>
 where
     Self: Encodable,
 {
-    /// Generate the [`TradeFingerprint`] from the trade. The fingerprint identifies the content of
-    /// an trade (**without the uuid**) by taking the hash value of its serialization.
-    pub fn fingerprint(&self) -> TradeFingerprint {
+    /// Generate the [`DealFingerprint`] from the deal parameters. The fingerprint identifies the
+    /// content of a deal parameters (**without the uuid**) by taking the hash value of its
+    /// serialization.
+    pub fn fingerprint(&self) -> DealFingerprint {
         let mut keccak = Keccak::v256();
         let mut out = [0u8; 32];
         keccak.update(&serialize(self)[16..]);
         keccak.finalize(&mut out);
-        TradeFingerprint(out)
+        DealFingerprint(out)
     }
 }
 
-impl<Amt, Bmt, Ti, F> Encodable for Trade<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> Encodable for DealParameters<Amt, Bmt, Ti, F>
 where
     Amt: CanonicalBytes,
     Bmt: CanonicalBytes,
@@ -309,7 +305,7 @@ where
     }
 }
 
-impl<Amt, Bmt, Ti, F> Decodable for Trade<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> Decodable for DealParameters<Amt, Bmt, Ti, F>
 where
     Amt: CanonicalBytes,
     Bmt: CanonicalBytes,
@@ -317,7 +313,7 @@ where
     F: CanonicalBytes,
 {
     fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
-        Ok(Trade {
+        Ok(DealParameters {
             uuid: Uuid::from_bytes_le(Decodable::consensus_decode(d)?),
             network: Decodable::consensus_decode(d)?,
             arbitrating_blockchain: Decodable::consensus_decode(d)?,
@@ -332,21 +328,21 @@ where
     }
 }
 
-impl_strict_encoding!(Trade<Amt, Bmt, Ti, F>, Amt: CanonicalBytes, Bmt: CanonicalBytes, Ti: CanonicalBytes, F: CanonicalBytes,);
+impl_strict_encoding!(DealParameters<Amt, Bmt, Ti, F>, Amt: CanonicalBytes, Bmt: CanonicalBytes, Ti: CanonicalBytes, F: CanonicalBytes,);
 
-/// A public trade is shared across [`TradeRole::Maker`]'s prefered network to signal is willing of
-/// trading some assets at some conditions. The assets and condition are defined in the [`Trade`],
-/// maker peer connection information are contained in the public trade.
+/// A deal is shared across [`TradeRole::Maker`]'s prefered network to signal is willing of trading
+/// some assets at some conditions. The assets and condition are defined in the [`DealParameters`],
+/// maker peer connection information are contained in the deal.
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]
-pub struct PublicTrade<Amt, Bmt, Ti, F> {
-    /// The public trade version.
+pub struct Deal<Amt, Bmt, Ti, F> {
+    /// The deal version.
     pub version: Version,
-    /// The content of the trade.
+    /// The content of the deal.
     #[serde(bound(serialize = "Amt: Display, Bmt: Display, Ti: Serialize, F: Serialize"))]
     #[serde(bound(
         deserialize = "Amt: FromStr, Amt::Err: Display, Bmt: FromStr, Bmt::Err: Display, Ti: Deserialize<'de>, F: Deserialize<'de>"
     ))]
-    pub trade: Trade<Amt, Bmt, Ti, F>,
+    pub parameters: DealParameters<Amt, Bmt, Ti, F>,
     /// Node public key, used both as an ID and encryption key for per-session ECDH.
     pub node_id: PublicKey,
     /// Address of the listening daemon's peer. An internet socket address, which consists of an IP
@@ -354,7 +350,7 @@ pub struct PublicTrade<Amt, Bmt, Ti, F> {
     pub peer_address: InetSocketAddr,
 }
 
-impl<Amt, Bmt, Ti, F> PublicTrade<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> Deal<Amt, Bmt, Ti, F>
 where
     Amt: Copy,
     Ti: Copy,
@@ -362,70 +358,70 @@ where
 {
     pub fn to_arbitrating_params(&self) -> ArbitratingParameters<Amt, Ti, F> {
         ArbitratingParameters {
-            arbitrating_amount: self.trade.arbitrating_amount,
-            cancel_timelock: self.trade.cancel_timelock,
-            punish_timelock: self.trade.punish_timelock,
-            fee_strategy: self.trade.fee_strategy,
+            arbitrating_amount: self.parameters.arbitrating_amount,
+            cancel_timelock: self.parameters.cancel_timelock,
+            punish_timelock: self.parameters.punish_timelock,
+            fee_strategy: self.parameters.fee_strategy,
         }
     }
 }
 
-impl<Amt, Bmt, Ti, F> PublicTrade<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> Deal<Amt, Bmt, Ti, F>
 where
     Self: Encodable,
 {
-    /// Generate the public trade [`TradeFingerprint`]. Serialized the public trade (**without
-    /// uuid**) and return its keccak hash.
-    pub fn fingerprint(&self) -> TradeFingerprint {
+    /// Generate the deal [`DealFingerprint`]. Serialized the deal (**without uuid**) and return
+    /// its keccak hash.
+    pub fn fingerprint(&self) -> DealFingerprint {
         let mut keccak = Keccak::v256();
         let mut out = [0u8; 32];
         let ser = serialize(self);
         keccak.update(&ser[..8]);
         keccak.update(&ser[24..]);
         keccak.finalize(&mut out);
-        TradeFingerprint(out)
+        DealFingerprint(out)
     }
 
-    /// Returns the hex string representation of the consensus encoded public trade.
+    /// Returns the hex string representation of the consensus encoded deal.
     pub fn to_hex(&self) -> String {
         serialize_hex(self)
     }
 }
 
-impl<Amt, Bmt, Ti, F> PublicTrade<Amt, Bmt, Ti, F> {
-    /// Return the unique trade identifier. Same as [`Self::uuid()`].
+impl<Amt, Bmt, Ti, F> Deal<Amt, Bmt, Ti, F> {
+    /// Return the unique deal identifier. Same as [`Self::uuid()`].
     pub fn id(&self) -> Uuid {
         self.uuid()
     }
 
-    /// Return the unique trade identifier.
+    /// Return the unique deal identifier.
     pub fn uuid(&self) -> Uuid {
-        self.trade.uuid()
+        self.parameters.uuid()
     }
 
-    /// Reset trade's uuid with a new identifier.
+    /// Reset deal's uuid with a new identifier.
     pub fn randomize_uuid(&mut self) {
-        self.trade.randomize_uuid();
+        self.parameters.randomize_uuid();
     }
 
-    /// Return the future swap role for the given trade role.
+    /// Return the future swap role for the given deal role.
     pub fn swap_role(&self, trade_role: &TradeRole) -> SwapRole {
-        self.trade.swap_role(trade_role)
+        self.parameters.swap_role(trade_role)
     }
 }
 
-impl<Amt, Bmt, Ti, F> Display for PublicTrade<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> Display for Deal<Amt, Bmt, Ti, F>
 where
     Self: Encodable,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let encoded = base58_monero::encode_check(consensus::serialize(self).as_ref())
             .expect("Encoding in base58 check works");
-        write!(f, "{}{}", PUB_TRADE_PREFIX, encoded)
+        write!(f, "{}{}", DEAL_PREFIX, encoded)
     }
 }
 
-impl<Amt, Bmt, Ti, F> FromStr for PublicTrade<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> FromStr for Deal<Amt, Bmt, Ti, F>
 where
     Amt: CanonicalBytes,
     Bmt: CanonicalBytes,
@@ -435,16 +431,16 @@ where
     type Err = consensus::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if &s[..6] != PUB_TRADE_PREFIX {
+        if &s[..5] != DEAL_PREFIX {
             return Err(consensus::Error::IncorrectMagicBytes);
         }
-        let decoded = base58_monero::decode_check(&s[6..]).map_err(consensus::Error::new)?;
+        let decoded = base58_monero::decode_check(&s[5..]).map_err(consensus::Error::new)?;
         let mut res = std::io::Cursor::new(decoded);
         Decodable::consensus_decode(&mut res)
     }
 }
 
-impl<Amt, Bmt, Ti, F> Encodable for PublicTrade<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> Encodable for Deal<Amt, Bmt, Ti, F>
 where
     Amt: CanonicalBytes,
     Bmt: CanonicalBytes,
@@ -452,9 +448,9 @@ where
     F: CanonicalBytes,
 {
     fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
-        let mut len = TRADE_MAGIC_BYTES.consensus_encode(s)?;
+        let mut len = DEAL_MAGIC_BYTES.consensus_encode(s)?;
         len += self.version.consensus_encode(s)?;
-        len += self.trade.consensus_encode(s)?;
+        len += self.parameters.consensus_encode(s)?;
         len += self.node_id.as_canonical_bytes().consensus_encode(s)?;
         len +=
             strict_encoding::StrictEncode::strict_encode(&self.peer_address, s).map_err(|_| {
@@ -467,7 +463,7 @@ where
     }
 }
 
-impl<Amt, Bmt, Ti, F> Decodable for PublicTrade<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> Decodable for Deal<Amt, Bmt, Ti, F>
 where
     Amt: CanonicalBytes,
     Bmt: CanonicalBytes,
@@ -476,12 +472,12 @@ where
 {
     fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
         let magic_bytes: [u8; 6] = Decodable::consensus_decode(d)?;
-        if magic_bytes != *TRADE_MAGIC_BYTES {
+        if magic_bytes != *DEAL_MAGIC_BYTES {
             return Err(consensus::Error::IncorrectMagicBytes);
         }
-        Ok(PublicTrade {
+        Ok(Deal {
             version: Decodable::consensus_decode(d)?,
-            trade: Decodable::consensus_decode(d)?,
+            parameters: Decodable::consensus_decode(d)?,
             node_id: PublicKey::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
             peer_address: strict_encoding::StrictDecode::strict_decode(d)
                 .map_err(consensus::Error::new)?,
@@ -489,7 +485,7 @@ where
     }
 }
 
-impl_strict_encoding!(PublicTrade<Amt, Bmt, Ti, F>, Amt: CanonicalBytes, Bmt: CanonicalBytes, Ti: CanonicalBytes, F: CanonicalBytes,);
+impl_strict_encoding!(Deal<Amt, Bmt, Ti, F>, Amt: CanonicalBytes, Bmt: CanonicalBytes, Ti: CanonicalBytes, F: CanonicalBytes,);
 
 #[cfg(test)]
 mod tests {
@@ -506,7 +502,7 @@ mod tests {
     use secp256k1::PublicKey;
     use uuid::uuid;
 
-    const S: &str = "Trade:Cke4ftrP5A7CRkYdGNd87TRU6sUP1kBKM1LQM2fvVdFMNR4gmBqNCsR11111uMM4pF11111112Lvo11111TBALTh113GTvtvqfD1111114A4TUWxWeBc1WxwGBKaUssrb6pnijjhnb6RAs1HBr1CaX7o1a1111111111111111111111111111111111111111115T1WG8uDoZeAW1q";
+    const S: &str = "Deal:Cke4ftrP5A7CRkYdGNd87TRU6sUP1kBKM1LQM2fvVdFMNR4gmBqNCsR11111uMM4pF11111112Lvo11111TBALTh113GTvtvqfD1111114A4TUWxWeBc1WxwGBKaUssrb6pnijjhnb6RAs1HBr1CaX7o1a1111111111111111111111111111111111111111115T1WG8uDoZeAW1q";
 
     lazy_static::lazy_static! {
         pub static ref NODE_ID: PublicKey = {
@@ -524,8 +520,8 @@ mod tests {
             )
         };
 
-        pub static ref TRADE: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> = {
-            Trade {
+        pub static ref DEAL_PARAMS: DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> = {
+            DealParameters {
                 uuid: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
                 network: Network::Testnet,
                 arbitrating_blockchain: Blockchain::Bitcoin,
@@ -541,56 +537,54 @@ mod tests {
     }
 
     #[test]
-    fn parse_public_trade() {
-        let pub_trade =
-            PublicTrade::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str(S);
-        assert!(pub_trade.is_ok());
+    fn parse_deal() {
+        let deal = Deal::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str(S);
+        assert!(deal.is_ok());
 
-        let pub_trade = pub_trade.unwrap();
-        assert_eq!(pub_trade.version, Version::new_v1());
-        assert_eq!(pub_trade.trade, TRADE.clone());
-        assert_eq!(pub_trade.node_id, *NODE_ID);
-        assert_eq!(pub_trade.peer_address, *PEER_ADDRESS);
+        let deal = deal.unwrap();
+        assert_eq!(deal.version, Version::new_v1());
+        assert_eq!(deal.parameters, DEAL_PARAMS.clone());
+        assert_eq!(deal.node_id, *NODE_ID);
+        assert_eq!(deal.peer_address, *PEER_ADDRESS);
     }
 
     #[test]
-    fn parse_public_trade_fail_without_prefix() {
-        let pub_trade =
-            PublicTrade::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str(
-                &S[5..],
-            );
-        match pub_trade {
+    fn parse_deal_fail_without_prefix() {
+        let deal =
+            Deal::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str(&S[5..]);
+        match deal {
             Err(consensus::Error::IncorrectMagicBytes) => (),
             _ => panic!("Should have return an error IncorrectMagicBytes"),
         }
     }
 
     #[test]
-    fn display_trade() {
-        assert_eq!(&format!("{}", *TRADE), "Uuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\nFingerprint: 0xd68b1483de11001050026ca012a2b440818dac23341384c60680f668b52697b0\nNetwork: Testnet\nBlockchain: Bitcoin\n- amount: 0.00001350 BTC\nBlockchain: Monero\n- amount: 0.000000010000 XMR\nTimelocks\n- cancel: 4 blocks\n- punish: 6 blocks\nFee strategy: 1 satoshi/vByte\nMaker swap role: Bob\n");
+    fn display_deal_params() {
+        assert_eq!(&format!("{}", *DEAL_PARAMS), "Uuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\nFingerprint: 0xd68b1483de11001050026ca012a2b440818dac23341384c60680f668b52697b0\nNetwork: Testnet\nBlockchain: Bitcoin\n- amount: 0.00001350 BTC\nBlockchain: Monero\n- amount: 0.000000010000 XMR\nTimelocks\n- cancel: 4 blocks\n- punish: 6 blocks\nFee strategy: 1 satoshi/vByte\nMaker swap role: Bob\n");
     }
 
     #[test]
-    fn display_public_trade() {
-        let pub_trade = TRADE.clone().to_public_v1(*NODE_ID, *PEER_ADDRESS);
-        assert_eq!(&format!("{}", pub_trade), S);
+    fn display_deal() {
+        let deal = DEAL_PARAMS.clone().to_v1(*NODE_ID, *PEER_ADDRESS);
+        assert_eq!(&format!("{}", deal), S);
     }
 
     #[test]
-    fn serialize_trade_in_yaml() {
-        let trade: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> = Trade {
-            uuid: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
-            network: Network::Testnet,
-            arbitrating_blockchain: Blockchain::Bitcoin,
-            accordant_blockchain: Blockchain::Monero,
-            arbitrating_amount: bitcoin::Amount::from_sat(5),
-            accordant_amount: monero::Amount::from_pico(6),
-            cancel_timelock: CSVTimelock::new(7),
-            punish_timelock: CSVTimelock::new(8),
-            fee_strategy: FeeStrategy::Fixed(SatPerVByte::from_sat(9)),
-            maker_role: SwapRole::Bob,
-        };
-        let s = serde_yaml::to_string(&trade).expect("Encode public trade in yaml");
+    fn serialize_deal_params_in_yaml() {
+        let deal_params: DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+            DealParameters {
+                uuid: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
+                network: Network::Testnet,
+                arbitrating_blockchain: Blockchain::Bitcoin,
+                accordant_blockchain: Blockchain::Monero,
+                arbitrating_amount: bitcoin::Amount::from_sat(5),
+                accordant_amount: monero::Amount::from_pico(6),
+                cancel_timelock: CSVTimelock::new(7),
+                punish_timelock: CSVTimelock::new(8),
+                fee_strategy: FeeStrategy::Fixed(SatPerVByte::from_sat(9)),
+                maker_role: SwapRole::Bob,
+            };
+        let s = serde_yaml::to_string(&deal_params).expect("Encode deal in yaml");
         assert_eq!(
             "---\nuuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\nnetwork: Testnet\narbitrating_blockchain: Bitcoin\naccordant_blockchain: Monero\narbitrating_amount: 0.00000005 BTC\naccordant_amount: 0.000000000006 XMR\ncancel_timelock: 7\npunish_timelock: 8\nfee_strategy:\n  Fixed: 9 satoshi/vByte\nmaker_role: Bob\n",
             s
@@ -598,11 +592,11 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_trade_from_yaml() {
+    fn deserialize_deal_params_from_yaml() {
         let s = "---\nuuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\nnetwork: Testnet\narbitrating_blockchain: Bitcoin\naccordant_blockchain: Monero\narbitrating_amount: 0.00000005 BTC\naccordant_amount: 0.000000000006 XMR\ncancel_timelock: 7\npunish_timelock: 8\nfee_strategy:\n  Fixed: 9 satoshi/vByte\nmaker_role: Bob\n";
-        let trade = serde_yaml::from_str(&s).expect("Decode trade from yaml");
+        let deal_params = serde_yaml::from_str(&s).expect("Decode deal from yaml");
         assert_eq!(
-            Trade {
+            DealParameters {
                 uuid: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
                 network: Network::Testnet,
                 arbitrating_blockchain: Blockchain::Bitcoin,
@@ -614,30 +608,30 @@ mod tests {
                 fee_strategy: FeeStrategy::Fixed(SatPerVByte::from_sat(9)),
                 maker_role: SwapRole::Bob,
             },
-            trade
+            deal_params
         );
     }
 
     #[test]
-    fn serialize_public_trade_in_yaml() {
-        let public_trade =
-            PublicTrade::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str("Trade:Cke4ftrP5A7CRkYdGNd87TRU6sUP1kBKM1W723UjzEWsNR4gmBqNCsR11111uMFubBevJ2E5fp6ZR11111TBALTh113GTvtvqfD1111114A4TTfifktDH7QZD71vpdfo6EVo2ds7KviHz7vYbLZDkgsMNb11111111111111111111111111111111111111111AfZ113XRBuL3QS1m")
-            .expect("Valid public trade");
-        let s = serde_yaml::to_string(&public_trade).expect("Encode public trade in yaml");
+    fn serialize_deal_in_yaml() {
+        let deal =
+            Deal::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str("Deal:Cke4ftrP5A7CRkYdGNd87TRU6sUP1kBKM1W723UjzEWsNR4gmBqNCsR11111uMFubBevJ2E5fp6ZR11111TBALTh113GTvtvqfD1111114A4TTfifktDH7QZD71vpdfo6EVo2ds7KviHz7vYbLZDkgsMNb11111111111111111111111111111111111111111AfZ113XRBuL3QS1m")
+            .expect("Valid deal");
+        let s = serde_yaml::to_string(&deal).expect("Encode deal in yaml");
         assert_eq!(
-            "---\nversion: 1\ntrade:\n  uuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\n  network: Local\n  arbitrating_blockchain: Bitcoin\n  accordant_blockchain: Monero\n  arbitrating_amount: 0.00001350 BTC\n  accordant_amount: 1000000.001000000000 XMR\n  cancel_timelock: 4\n  punish_timelock: 6\n  fee_strategy:\n    Fixed: 1 satoshi/vByte\n  maker_role: Bob\nnode_id: 02e77b779cdc2c713823f7a19147a67e4209c74d77e2cb5045bce0584a6be064d4\npeer_address:\n  IPv4: \"127.0.0.1:9735\"\n",
+            "---\nversion: 1\nparameters:\n  uuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\n  network: Local\n  arbitrating_blockchain: Bitcoin\n  accordant_blockchain: Monero\n  arbitrating_amount: 0.00001350 BTC\n  accordant_amount: 1000000.001000000000 XMR\n  cancel_timelock: 4\n  punish_timelock: 6\n  fee_strategy:\n    Fixed: 1 satoshi/vByte\n  maker_role: Bob\nnode_id: 02e77b779cdc2c713823f7a19147a67e4209c74d77e2cb5045bce0584a6be064d4\npeer_address:\n  IPv4: \"127.0.0.1:9735\"\n",
             s
         );
     }
 
     #[test]
-    fn deserialize_public_trade_from_yaml() {
-        let s = "---\nversion: 1\ntrade:\n  uuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\n  network: Local\n  arbitrating_blockchain: Bitcoin\n  accordant_blockchain: Monero\n  arbitrating_amount: 0.00001350 BTC\n  accordant_amount: 1000000.001000000000 XMR\n  cancel_timelock: 4\n  punish_timelock: 6\n  fee_strategy:\n    Fixed: 1 satoshi/vByte\n  maker_role: Bob\nnode_id: 02e77b779cdc2c713823f7a19147a67e4209c74d77e2cb5045bce0584a6be064d4\npeer_address:\n  IPv4: \"127.0.0.1:9735\"\n";
-        let public_trade = serde_yaml::from_str(&s).expect("Decode public trade from yaml");
+    fn deserialize_deal_from_yaml() {
+        let s = "---\nversion: 1\nparameters:\n  uuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\n  network: Local\n  arbitrating_blockchain: Bitcoin\n  accordant_blockchain: Monero\n  arbitrating_amount: 0.00001350 BTC\n  accordant_amount: 1000000.001000000000 XMR\n  cancel_timelock: 4\n  punish_timelock: 6\n  fee_strategy:\n    Fixed: 1 satoshi/vByte\n  maker_role: Bob\nnode_id: 02e77b779cdc2c713823f7a19147a67e4209c74d77e2cb5045bce0584a6be064d4\npeer_address:\n  IPv4: \"127.0.0.1:9735\"\n";
+        let deal = serde_yaml::from_str(&s).expect("Decode deal from yaml");
         assert_eq!(
-            PublicTrade::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str("Trade:Cke4ftrP5A7CRkYdGNd87TRU6sUP1kBKM1W723UjzEWsNR4gmBqNCsR11111uMFubBevJ2E5fp6ZR11111TBALTh113GTvtvqfD1111114A4TTfifktDH7QZD71vpdfo6EVo2ds7KviHz7vYbLZDkgsMNb11111111111111111111111111111111111111111AfZ113XRBuL3QS1m")
-                .expect("Valid public trade"),
-            public_trade
+            Deal::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str("Deal:Cke4ftrP5A7CRkYdGNd87TRU6sUP1kBKM1W723UjzEWsNR4gmBqNCsR11111uMFubBevJ2E5fp6ZR11111TBALTh113GTvtvqfD1111114A4TTfifktDH7QZD71vpdfo6EVo2ds7KviHz7vYbLZDkgsMNb11111111111111111111111111111111111111111AfZ113XRBuL3QS1m")
+                .expect("Valid deal"),
+            deal
         );
     }
 }

--- a/src/trade.rs
+++ b/src/trade.rs
@@ -14,24 +14,24 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
-//! Offer helpers and structures. Buyer and seller helpers to create offer and public offers
+//! Trade helpers and structures. Buyer and seller helpers to create trade and public trades
 //! allowing agreement on assets, quantities and parameters of a swap among maker and taker.
 //!
-//! ## Public Offer
+//! ## Public Trade
 //!
-//! A public offer is shared across the network by a maker. It contains all the data regarding what
+//! A public trade is shared across the network by a maker. It contains all the data regarding what
 //! the trade is about (assets, amounts, timings, etc.).
 //!
-//! A public offer is formatted like (base58 is Monero base58):
+//! A public trade is formatted like (base58 is Monero base58):
 //!
 //! ```text
-//! "Offer:" | base58(serialize(public_offer))
+//! "Trade:" | base58(serialize(public_trade))
 //! ```
 //!
-//! The public offer contains:
+//! The public trade contains:
 //!
 //! - A version number, used for the version and potentially enabling features
-//! - The offer, containing the asset types, amounts, timings, etc.
+//! - The trade, containing the asset types, amounts, timings, etc.
 //! - A node identifier, used to secure the communication with the other peer
 //! - A peer address, used to connect to the other peer
 
@@ -52,26 +52,26 @@ use crate::blockchain::{Blockchain, FeeStrategy, Network};
 use crate::consensus::{self, serialize, serialize_hex, CanonicalBytes, Decodable, Encodable};
 use crate::hash::HashString;
 use crate::protocol::ArbitratingParameters;
-use crate::role::{SwapRole, OfferRole};
+use crate::role::{SwapRole, TradeRole};
 
-/// First six magic bytes of a public offer. Bytes are included inside the base58 encoded part.
-pub const OFFER_MAGIC_BYTES: &[u8; 6] = b"FCSWAP";
+/// First six magic bytes of a public trade. Bytes are included inside the base58 encoded part.
+pub const TRADE_MAGIC_BYTES: &[u8; 6] = b"FCSWAP";
 
-/// Prefix for serialized public offer.
-pub const PUB_OFFER_PREFIX: &str = "Offer:";
+/// Prefix for serialized public trade.
+pub const PUB_TRADE_PREFIX: &str = "Trade:";
 
-/// A public offer version containing the version and the activated features if any.
+/// A public trade version containing the version and the activated features if any.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Display, Serialize, Deserialize)]
 #[display("v{0}")]
 pub struct Version(u16);
 
 impl Version {
-    /// Create a new version 1 public offer.
+    /// Create a new version 1 public trade.
     pub fn new_v1() -> Self {
         Self::new(1)
     }
 
-    /// Create a public offer from a raw version and feature `u16`.
+    /// Create a public trade from a raw version and feature `u16`.
     pub fn new(version: u16) -> Self {
         Version(version)
     }
@@ -94,24 +94,24 @@ impl Decodable for Version {
     }
 }
 
-/// Offer errors used when manipulating offers, public offers and its version.
+/// Trade errors used when manipulating trades, public trades and its version.
 #[derive(Error, Debug)]
 pub enum Error {
-    /// The public offer version is not supported.
+    /// The public trade version is not supported.
     #[error("Unsupported version")]
     UnsupportedVersion,
-    /// The public offer signature does not pass the validation tests.
+    /// The public trade signature does not pass the validation tests.
     #[error("Invalid signature")]
     InvalidSignature,
 }
 
 fixed_hash::construct_fixed_hash!(
-    /// Identify an offer by it's content, internally store the hash of the offer serialized with
+    /// Identify an trade by it's content, internally store the hash of the trade serialized with
     /// Farcaster consensus.
-    pub struct OfferFingerprint(32);
+    pub struct TradeFingerprint(32);
 );
 
-impl Serialize for OfferFingerprint {
+impl Serialize for TradeFingerprint {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -120,20 +120,20 @@ impl Serialize for OfferFingerprint {
     }
 }
 
-impl<'de> Deserialize<'de> for OfferFingerprint {
-    fn deserialize<D>(deserializer: D) -> Result<OfferFingerprint, D::Error>
+impl<'de> Deserialize<'de> for TradeFingerprint {
+    fn deserialize<D>(deserializer: D) -> Result<TradeFingerprint, D::Error>
     where
         D: Deserializer<'de>,
     {
-        OfferFingerprint::from_str(&deserializer.deserialize_string(HashString)?)
+        TradeFingerprint::from_str(&deserializer.deserialize_string(HashString)?)
             .map_err(de::Error::custom)
     }
 }
 
-/// An offer is created by a [`OfferRole::Maker`] before the start of his daemon, it references all
-/// the data needed to parametrize a trade and be validated from a [`OfferRole::Taker`]
-/// perspective. The daemon start when the maker is ready to finalize his offer, transforming the
-/// offer into a [`PublicOffer`] which contains the data needed to a taker to connect to the
+/// An trade is created by a [`TradeRole::Maker`] before the start of his daemon, it references all
+/// the data needed to parametrize a trade and be validated from a [`TradeRole::Taker`]
+/// perspective. The daemon start when the maker is ready to finalize his trade, transforming the
+/// trade into a [`PublicTrade`] which contains the data needed to a taker to connect to the
 /// maker's daemon.
 ///
 /// ## Serde implementation
@@ -141,10 +141,10 @@ impl<'de> Deserialize<'de> for OfferFingerprint {
 /// xmr and pico for monero. Using [`Display`] and [`FromStr`] unifies the interface to
 /// de/serialize generic amounts.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct Offer<Amt, Bmt, Ti, F> {
-    /// The offer unique identifier.
+pub struct Trade<Amt, Bmt, Ti, F> {
+    /// The trade unique identifier.
     pub uuid: Uuid,
-    /// Type of offer and network to use.
+    /// Type of trade and network to use.
     pub network: Network,
     /// The chosen arbitrating blockchain.
     pub arbitrating_blockchain: Blockchain,
@@ -196,7 +196,7 @@ mod string {
     }
 }
 
-impl<Amt, Bmt, Ti, F> Display for Offer<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> Display for Trade<Amt, Bmt, Ti, F>
 where
     Self: Encodable,
     Amt: Display,
@@ -220,63 +220,63 @@ where
     }
 }
 
-impl<Amt, Bmt, Ti, F> Offer<Amt, Bmt, Ti, F> {
-    /// Transform the offer in a public offer of [`Version`] 1.
+impl<Amt, Bmt, Ti, F> Trade<Amt, Bmt, Ti, F> {
+    /// Transform the trade in a public trade of [`Version`] 1.
     pub fn to_public_v1(
         self,
         node_id: PublicKey,
         peer_address: InetSocketAddr,
-    ) -> PublicOffer<Amt, Bmt, Ti, F> {
-        PublicOffer {
+    ) -> PublicTrade<Amt, Bmt, Ti, F> {
+        PublicTrade {
             version: Version::new_v1(),
-            offer: self,
+            trade: self,
             node_id,
             peer_address,
         }
     }
 
     /// Return the future swap role for the given trade role.
-    pub fn swap_role(&self, trade_role: &OfferRole) -> SwapRole {
+    pub fn swap_role(&self, trade_role: &TradeRole) -> SwapRole {
         match trade_role {
-            OfferRole::Maker => self.maker_role,
-            OfferRole::Taker => self.maker_role.other(),
+            TradeRole::Maker => self.maker_role,
+            TradeRole::Taker => self.maker_role.other(),
         }
     }
 }
 
-impl<Amt, Bmt, Ti, F> Offer<Amt, Bmt, Ti, F> {
-    /// Return the unique offer identifier. Same as [`Self::uuid()`].
+impl<Amt, Bmt, Ti, F> Trade<Amt, Bmt, Ti, F> {
+    /// Return the unique trade identifier. Same as [`Self::uuid()`].
     pub fn id(&self) -> Uuid {
         self.uuid()
     }
 
-    /// Return the unique offer identifier.
+    /// Return the unique trade identifier.
     pub fn uuid(&self) -> Uuid {
         self.uuid
     }
 
-    /// Reset offer's uuid with a new identifier.
+    /// Reset trade's uuid with a new identifier.
     pub fn randomize_uuid(&mut self) {
         self.uuid = Uuid::new_v4();
     }
 }
 
-impl<Amt, Bmt, Ti, F> Offer<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> Trade<Amt, Bmt, Ti, F>
 where
     Self: Encodable,
 {
-    /// Generate the [`OfferFingerprint`] from the offer. The fingerprint identifies the content of
-    /// an offer (**without the uuid**) by taking the hash value of its serialization.
-    pub fn fingerprint(&self) -> OfferFingerprint {
+    /// Generate the [`TradeFingerprint`] from the trade. The fingerprint identifies the content of
+    /// an trade (**without the uuid**) by taking the hash value of its serialization.
+    pub fn fingerprint(&self) -> TradeFingerprint {
         let mut keccak = Keccak::v256();
         let mut out = [0u8; 32];
         keccak.update(&serialize(self)[16..]);
         keccak.finalize(&mut out);
-        OfferFingerprint(out)
+        TradeFingerprint(out)
     }
 }
 
-impl<Amt, Bmt, Ti, F> Encodable for Offer<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> Encodable for Trade<Amt, Bmt, Ti, F>
 where
     Amt: CanonicalBytes,
     Bmt: CanonicalBytes,
@@ -309,7 +309,7 @@ where
     }
 }
 
-impl<Amt, Bmt, Ti, F> Decodable for Offer<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> Decodable for Trade<Amt, Bmt, Ti, F>
 where
     Amt: CanonicalBytes,
     Bmt: CanonicalBytes,
@@ -317,7 +317,7 @@ where
     F: CanonicalBytes,
 {
     fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
-        Ok(Offer {
+        Ok(Trade {
             uuid: Uuid::from_bytes_le(Decodable::consensus_decode(d)?),
             network: Decodable::consensus_decode(d)?,
             arbitrating_blockchain: Decodable::consensus_decode(d)?,
@@ -332,21 +332,21 @@ where
     }
 }
 
-impl_strict_encoding!(Offer<Amt, Bmt, Ti, F>, Amt: CanonicalBytes, Bmt: CanonicalBytes, Ti: CanonicalBytes, F: CanonicalBytes,);
+impl_strict_encoding!(Trade<Amt, Bmt, Ti, F>, Amt: CanonicalBytes, Bmt: CanonicalBytes, Ti: CanonicalBytes, F: CanonicalBytes,);
 
-/// A public offer is shared across [`OfferRole::Maker`]'s prefered network to signal is willing of
-/// trading some assets at some conditions. The assets and condition are defined in the [`Offer`],
-/// maker peer connection information are contained in the public offer.
+/// A public trade is shared across [`TradeRole::Maker`]'s prefered network to signal is willing of
+/// trading some assets at some conditions. The assets and condition are defined in the [`Trade`],
+/// maker peer connection information are contained in the public trade.
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]
-pub struct PublicOffer<Amt, Bmt, Ti, F> {
-    /// The public offer version.
+pub struct PublicTrade<Amt, Bmt, Ti, F> {
+    /// The public trade version.
     pub version: Version,
-    /// The content of the offer.
+    /// The content of the trade.
     #[serde(bound(serialize = "Amt: Display, Bmt: Display, Ti: Serialize, F: Serialize"))]
     #[serde(bound(
         deserialize = "Amt: FromStr, Amt::Err: Display, Bmt: FromStr, Bmt::Err: Display, Ti: Deserialize<'de>, F: Deserialize<'de>"
     ))]
-    pub offer: Offer<Amt, Bmt, Ti, F>,
+    pub trade: Trade<Amt, Bmt, Ti, F>,
     /// Node public key, used both as an ID and encryption key for per-session ECDH.
     pub node_id: PublicKey,
     /// Address of the listening daemon's peer. An internet socket address, which consists of an IP
@@ -354,7 +354,7 @@ pub struct PublicOffer<Amt, Bmt, Ti, F> {
     pub peer_address: InetSocketAddr,
 }
 
-impl<Amt, Bmt, Ti, F> PublicOffer<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> PublicTrade<Amt, Bmt, Ti, F>
 where
     Amt: Copy,
     Ti: Copy,
@@ -362,70 +362,70 @@ where
 {
     pub fn to_arbitrating_params(&self) -> ArbitratingParameters<Amt, Ti, F> {
         ArbitratingParameters {
-            arbitrating_amount: self.offer.arbitrating_amount,
-            cancel_timelock: self.offer.cancel_timelock,
-            punish_timelock: self.offer.punish_timelock,
-            fee_strategy: self.offer.fee_strategy,
+            arbitrating_amount: self.trade.arbitrating_amount,
+            cancel_timelock: self.trade.cancel_timelock,
+            punish_timelock: self.trade.punish_timelock,
+            fee_strategy: self.trade.fee_strategy,
         }
     }
 }
 
-impl<Amt, Bmt, Ti, F> PublicOffer<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> PublicTrade<Amt, Bmt, Ti, F>
 where
     Self: Encodable,
 {
-    /// Generate the public offer [`OfferFingerprint`]. Serialized the public offer (**without
+    /// Generate the public trade [`TradeFingerprint`]. Serialized the public trade (**without
     /// uuid**) and return its keccak hash.
-    pub fn fingerprint(&self) -> OfferFingerprint {
+    pub fn fingerprint(&self) -> TradeFingerprint {
         let mut keccak = Keccak::v256();
         let mut out = [0u8; 32];
         let ser = serialize(self);
         keccak.update(&ser[..8]);
         keccak.update(&ser[24..]);
         keccak.finalize(&mut out);
-        OfferFingerprint(out)
+        TradeFingerprint(out)
     }
 
-    /// Returns the hex string representation of the consensus encoded public offer.
+    /// Returns the hex string representation of the consensus encoded public trade.
     pub fn to_hex(&self) -> String {
         serialize_hex(self)
     }
 }
 
-impl<Amt, Bmt, Ti, F> PublicOffer<Amt, Bmt, Ti, F> {
-    /// Return the unique offer identifier. Same as [`Self::uuid()`].
+impl<Amt, Bmt, Ti, F> PublicTrade<Amt, Bmt, Ti, F> {
+    /// Return the unique trade identifier. Same as [`Self::uuid()`].
     pub fn id(&self) -> Uuid {
         self.uuid()
     }
 
-    /// Return the unique offer identifier.
+    /// Return the unique trade identifier.
     pub fn uuid(&self) -> Uuid {
-        self.offer.uuid()
+        self.trade.uuid()
     }
 
-    /// Reset offer's uuid with a new identifier.
+    /// Reset trade's uuid with a new identifier.
     pub fn randomize_uuid(&mut self) {
-        self.offer.randomize_uuid();
+        self.trade.randomize_uuid();
     }
 
     /// Return the future swap role for the given trade role.
-    pub fn swap_role(&self, trade_role: &OfferRole) -> SwapRole {
-        self.offer.swap_role(trade_role)
+    pub fn swap_role(&self, trade_role: &TradeRole) -> SwapRole {
+        self.trade.swap_role(trade_role)
     }
 }
 
-impl<Amt, Bmt, Ti, F> Display for PublicOffer<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> Display for PublicTrade<Amt, Bmt, Ti, F>
 where
     Self: Encodable,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let encoded = base58_monero::encode_check(consensus::serialize(self).as_ref())
             .expect("Encoding in base58 check works");
-        write!(f, "{}{}", PUB_OFFER_PREFIX, encoded)
+        write!(f, "{}{}", PUB_TRADE_PREFIX, encoded)
     }
 }
 
-impl<Amt, Bmt, Ti, F> FromStr for PublicOffer<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> FromStr for PublicTrade<Amt, Bmt, Ti, F>
 where
     Amt: CanonicalBytes,
     Bmt: CanonicalBytes,
@@ -435,7 +435,7 @@ where
     type Err = consensus::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if &s[..6] != PUB_OFFER_PREFIX {
+        if &s[..6] != PUB_TRADE_PREFIX {
             return Err(consensus::Error::IncorrectMagicBytes);
         }
         let decoded = base58_monero::decode_check(&s[6..]).map_err(consensus::Error::new)?;
@@ -444,7 +444,7 @@ where
     }
 }
 
-impl<Amt, Bmt, Ti, F> Encodable for PublicOffer<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> Encodable for PublicTrade<Amt, Bmt, Ti, F>
 where
     Amt: CanonicalBytes,
     Bmt: CanonicalBytes,
@@ -452,9 +452,9 @@ where
     F: CanonicalBytes,
 {
     fn consensus_encode<W: io::Write>(&self, s: &mut W) -> Result<usize, io::Error> {
-        let mut len = OFFER_MAGIC_BYTES.consensus_encode(s)?;
+        let mut len = TRADE_MAGIC_BYTES.consensus_encode(s)?;
         len += self.version.consensus_encode(s)?;
-        len += self.offer.consensus_encode(s)?;
+        len += self.trade.consensus_encode(s)?;
         len += self.node_id.as_canonical_bytes().consensus_encode(s)?;
         len +=
             strict_encoding::StrictEncode::strict_encode(&self.peer_address, s).map_err(|_| {
@@ -467,7 +467,7 @@ where
     }
 }
 
-impl<Amt, Bmt, Ti, F> Decodable for PublicOffer<Amt, Bmt, Ti, F>
+impl<Amt, Bmt, Ti, F> Decodable for PublicTrade<Amt, Bmt, Ti, F>
 where
     Amt: CanonicalBytes,
     Bmt: CanonicalBytes,
@@ -476,12 +476,12 @@ where
 {
     fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
         let magic_bytes: [u8; 6] = Decodable::consensus_decode(d)?;
-        if magic_bytes != *OFFER_MAGIC_BYTES {
+        if magic_bytes != *TRADE_MAGIC_BYTES {
             return Err(consensus::Error::IncorrectMagicBytes);
         }
-        Ok(PublicOffer {
+        Ok(PublicTrade {
             version: Decodable::consensus_decode(d)?,
-            offer: Decodable::consensus_decode(d)?,
+            trade: Decodable::consensus_decode(d)?,
             node_id: PublicKey::from_canonical_bytes(unwrap_vec_ref!(d).as_ref())?,
             peer_address: strict_encoding::StrictDecode::strict_decode(d)
                 .map_err(consensus::Error::new)?,
@@ -489,7 +489,7 @@ where
     }
 }
 
-impl_strict_encoding!(PublicOffer<Amt, Bmt, Ti, F>, Amt: CanonicalBytes, Bmt: CanonicalBytes, Ti: CanonicalBytes, F: CanonicalBytes,);
+impl_strict_encoding!(PublicTrade<Amt, Bmt, Ti, F>, Amt: CanonicalBytes, Bmt: CanonicalBytes, Ti: CanonicalBytes, F: CanonicalBytes,);
 
 #[cfg(test)]
 mod tests {
@@ -506,7 +506,7 @@ mod tests {
     use secp256k1::PublicKey;
     use uuid::uuid;
 
-    const S: &str = "Offer:Cke4ftrP5A7CRkYdGNd87TRU6sUP1kBKM1LQM2fvVdFMNR4gmBqNCsR11111uMM4pF11111112Lvo11111TBALTh113GTvtvqfD1111114A4TUWxWeBc1WxwGBKaUssrb6pnijjhnb6RAs1HBr1CaX7o1a1111111111111111111111111111111111111111115T1WG8uDoZeAW1q";
+    const S: &str = "Trade:Cke4ftrP5A7CRkYdGNd87TRU6sUP1kBKM1LQM2fvVdFMNR4gmBqNCsR11111uMM4pF11111112Lvo11111TBALTh113GTvtvqfD1111114A4TUWxWeBc1WxwGBKaUssrb6pnijjhnb6RAs1HBr1CaX7o1a1111111111111111111111111111111111111111115T1WG8uDoZeAW1q";
 
     lazy_static::lazy_static! {
         pub static ref NODE_ID: PublicKey = {
@@ -524,8 +524,8 @@ mod tests {
             )
         };
 
-        pub static ref OFFER: Offer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> = {
-            Offer {
+        pub static ref TRADE: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> = {
+            Trade {
                 uuid: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
                 network: Network::Testnet,
                 arbitrating_blockchain: Blockchain::Bitcoin,
@@ -541,44 +541,44 @@ mod tests {
     }
 
     #[test]
-    fn parse_public_offer() {
-        let pub_offer =
-            PublicOffer::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str(S);
-        assert!(pub_offer.is_ok());
+    fn parse_public_trade() {
+        let pub_trade =
+            PublicTrade::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str(S);
+        assert!(pub_trade.is_ok());
 
-        let pub_offer = pub_offer.unwrap();
-        assert_eq!(pub_offer.version, Version::new_v1());
-        assert_eq!(pub_offer.offer, OFFER.clone());
-        assert_eq!(pub_offer.node_id, *NODE_ID);
-        assert_eq!(pub_offer.peer_address, *PEER_ADDRESS);
+        let pub_trade = pub_trade.unwrap();
+        assert_eq!(pub_trade.version, Version::new_v1());
+        assert_eq!(pub_trade.trade, TRADE.clone());
+        assert_eq!(pub_trade.node_id, *NODE_ID);
+        assert_eq!(pub_trade.peer_address, *PEER_ADDRESS);
     }
 
     #[test]
-    fn parse_public_offer_fail_without_prefix() {
-        let pub_offer =
-            PublicOffer::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str(
+    fn parse_public_trade_fail_without_prefix() {
+        let pub_trade =
+            PublicTrade::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str(
                 &S[5..],
             );
-        match pub_offer {
+        match pub_trade {
             Err(consensus::Error::IncorrectMagicBytes) => (),
             _ => panic!("Should have return an error IncorrectMagicBytes"),
         }
     }
 
     #[test]
-    fn display_offer() {
-        assert_eq!(&format!("{}", *OFFER), "Uuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\nFingerprint: 0xd68b1483de11001050026ca012a2b440818dac23341384c60680f668b52697b0\nNetwork: Testnet\nBlockchain: Bitcoin\n- amount: 0.00001350 BTC\nBlockchain: Monero\n- amount: 0.000000010000 XMR\nTimelocks\n- cancel: 4 blocks\n- punish: 6 blocks\nFee strategy: 1 satoshi/vByte\nMaker swap role: Bob\n");
+    fn display_trade() {
+        assert_eq!(&format!("{}", *TRADE), "Uuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\nFingerprint: 0xd68b1483de11001050026ca012a2b440818dac23341384c60680f668b52697b0\nNetwork: Testnet\nBlockchain: Bitcoin\n- amount: 0.00001350 BTC\nBlockchain: Monero\n- amount: 0.000000010000 XMR\nTimelocks\n- cancel: 4 blocks\n- punish: 6 blocks\nFee strategy: 1 satoshi/vByte\nMaker swap role: Bob\n");
     }
 
     #[test]
-    fn display_public_offer() {
-        let pub_offer = OFFER.clone().to_public_v1(*NODE_ID, *PEER_ADDRESS);
-        assert_eq!(&format!("{}", pub_offer), S);
+    fn display_public_trade() {
+        let pub_trade = TRADE.clone().to_public_v1(*NODE_ID, *PEER_ADDRESS);
+        assert_eq!(&format!("{}", pub_trade), S);
     }
 
     #[test]
-    fn serialize_offer_in_yaml() {
-        let offer: Offer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> = Offer {
+    fn serialize_trade_in_yaml() {
+        let trade: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> = Trade {
             uuid: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
             network: Network::Testnet,
             arbitrating_blockchain: Blockchain::Bitcoin,
@@ -590,7 +590,7 @@ mod tests {
             fee_strategy: FeeStrategy::Fixed(SatPerVByte::from_sat(9)),
             maker_role: SwapRole::Bob,
         };
-        let s = serde_yaml::to_string(&offer).expect("Encode public offer in yaml");
+        let s = serde_yaml::to_string(&trade).expect("Encode public trade in yaml");
         assert_eq!(
             "---\nuuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\nnetwork: Testnet\narbitrating_blockchain: Bitcoin\naccordant_blockchain: Monero\narbitrating_amount: 0.00000005 BTC\naccordant_amount: 0.000000000006 XMR\ncancel_timelock: 7\npunish_timelock: 8\nfee_strategy:\n  Fixed: 9 satoshi/vByte\nmaker_role: Bob\n",
             s
@@ -598,11 +598,11 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_offer_from_yaml() {
+    fn deserialize_trade_from_yaml() {
         let s = "---\nuuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\nnetwork: Testnet\narbitrating_blockchain: Bitcoin\naccordant_blockchain: Monero\narbitrating_amount: 0.00000005 BTC\naccordant_amount: 0.000000000006 XMR\ncancel_timelock: 7\npunish_timelock: 8\nfee_strategy:\n  Fixed: 9 satoshi/vByte\nmaker_role: Bob\n";
-        let offer = serde_yaml::from_str(&s).expect("Decode offer from yaml");
+        let trade = serde_yaml::from_str(&s).expect("Decode trade from yaml");
         assert_eq!(
-            Offer {
+            Trade {
                 uuid: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
                 network: Network::Testnet,
                 arbitrating_blockchain: Blockchain::Bitcoin,
@@ -614,30 +614,30 @@ mod tests {
                 fee_strategy: FeeStrategy::Fixed(SatPerVByte::from_sat(9)),
                 maker_role: SwapRole::Bob,
             },
-            offer
+            trade
         );
     }
 
     #[test]
-    fn serialize_public_offer_in_yaml() {
-        let public_offer =
-            PublicOffer::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str("Offer:Cke4ftrP5A7CRkYdGNd87TRU6sUP1kBKM1W723UjzEWsNR4gmBqNCsR11111uMFubBevJ2E5fp6ZR11111TBALTh113GTvtvqfD1111114A4TTfifktDH7QZD71vpdfo6EVo2ds7KviHz7vYbLZDkgsMNb11111111111111111111111111111111111111111AfZ113XRBuL3QS1m")
-            .expect("Valid public offer");
-        let s = serde_yaml::to_string(&public_offer).expect("Encode public offer in yaml");
+    fn serialize_public_trade_in_yaml() {
+        let public_trade =
+            PublicTrade::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str("Trade:Cke4ftrP5A7CRkYdGNd87TRU6sUP1kBKM1W723UjzEWsNR4gmBqNCsR11111uMFubBevJ2E5fp6ZR11111TBALTh113GTvtvqfD1111114A4TTfifktDH7QZD71vpdfo6EVo2ds7KviHz7vYbLZDkgsMNb11111111111111111111111111111111111111111AfZ113XRBuL3QS1m")
+            .expect("Valid public trade");
+        let s = serde_yaml::to_string(&public_trade).expect("Encode public trade in yaml");
         assert_eq!(
-            "---\nversion: 1\noffer:\n  uuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\n  network: Local\n  arbitrating_blockchain: Bitcoin\n  accordant_blockchain: Monero\n  arbitrating_amount: 0.00001350 BTC\n  accordant_amount: 1000000.001000000000 XMR\n  cancel_timelock: 4\n  punish_timelock: 6\n  fee_strategy:\n    Fixed: 1 satoshi/vByte\n  maker_role: Bob\nnode_id: 02e77b779cdc2c713823f7a19147a67e4209c74d77e2cb5045bce0584a6be064d4\npeer_address:\n  IPv4: \"127.0.0.1:9735\"\n",
+            "---\nversion: 1\ntrade:\n  uuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\n  network: Local\n  arbitrating_blockchain: Bitcoin\n  accordant_blockchain: Monero\n  arbitrating_amount: 0.00001350 BTC\n  accordant_amount: 1000000.001000000000 XMR\n  cancel_timelock: 4\n  punish_timelock: 6\n  fee_strategy:\n    Fixed: 1 satoshi/vByte\n  maker_role: Bob\nnode_id: 02e77b779cdc2c713823f7a19147a67e4209c74d77e2cb5045bce0584a6be064d4\npeer_address:\n  IPv4: \"127.0.0.1:9735\"\n",
             s
         );
     }
 
     #[test]
-    fn deserialize_public_offer_from_yaml() {
-        let s = "---\nversion: 1\noffer:\n  uuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\n  network: Local\n  arbitrating_blockchain: Bitcoin\n  accordant_blockchain: Monero\n  arbitrating_amount: 0.00001350 BTC\n  accordant_amount: 1000000.001000000000 XMR\n  cancel_timelock: 4\n  punish_timelock: 6\n  fee_strategy:\n    Fixed: 1 satoshi/vByte\n  maker_role: Bob\nnode_id: 02e77b779cdc2c713823f7a19147a67e4209c74d77e2cb5045bce0584a6be064d4\npeer_address:\n  IPv4: \"127.0.0.1:9735\"\n";
-        let public_offer = serde_yaml::from_str(&s).expect("Decode public offer from yaml");
+    fn deserialize_public_trade_from_yaml() {
+        let s = "---\nversion: 1\ntrade:\n  uuid: 67e55044-10b1-426f-9247-bb680e5fe0c8\n  network: Local\n  arbitrating_blockchain: Bitcoin\n  accordant_blockchain: Monero\n  arbitrating_amount: 0.00001350 BTC\n  accordant_amount: 1000000.001000000000 XMR\n  cancel_timelock: 4\n  punish_timelock: 6\n  fee_strategy:\n    Fixed: 1 satoshi/vByte\n  maker_role: Bob\nnode_id: 02e77b779cdc2c713823f7a19147a67e4209c74d77e2cb5045bce0584a6be064d4\npeer_address:\n  IPv4: \"127.0.0.1:9735\"\n";
+        let public_trade = serde_yaml::from_str(&s).expect("Decode public trade from yaml");
         assert_eq!(
-            PublicOffer::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str("Offer:Cke4ftrP5A7CRkYdGNd87TRU6sUP1kBKM1W723UjzEWsNR4gmBqNCsR11111uMFubBevJ2E5fp6ZR11111TBALTh113GTvtvqfD1111114A4TTfifktDH7QZD71vpdfo6EVo2ds7KviHz7vYbLZDkgsMNb11111111111111111111111111111111111111111AfZ113XRBuL3QS1m")
-                .expect("Valid public offer"),
-            public_offer
+            PublicTrade::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str("Trade:Cke4ftrP5A7CRkYdGNd87TRU6sUP1kBKM1W723UjzEWsNR4gmBqNCsR11111uMFubBevJ2E5fp6ZR11111TBALTh113GTvtvqfD1111114A4TTfifktDH7QZD71vpdfo6EVo2ds7KviHz7vYbLZDkgsMNb11111111111111111111111111111111111111111AfZ113XRBuL3QS1m")
+                .expect("Valid public trade"),
+            public_trade
         );
     }
 }

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -26,7 +26,7 @@ use farcaster_core::crypto::{
     ArbitratingKeyId, CommitmentEngine, GenerateKey, ProveCrossGroupDleq,
 };
 use farcaster_core::protocol::message::*;
-use farcaster_core::swap::btcxmr::{Alice, Bob, Parameters, PublicTrade};
+use farcaster_core::swap::btcxmr::{Alice, Bob, Deal, Parameters};
 use farcaster_core::swap::SwapId;
 use farcaster_core::transaction::*;
 
@@ -50,7 +50,7 @@ macro_rules! test_strict_ser {
     };
 }
 
-fn init() -> (Alice, Bob, PublicTrade) {
+fn init() -> (Alice, Bob, Deal) {
     let hex = "46435357415001004450e567b1106f429247bb680e5fe0c80200000080800000800800a08601000\
                00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
@@ -62,7 +62,7 @@ fn init() -> (Alice, Bob, PublicTrade) {
     let refund = Address::from_str("bc1qesgvtyx9y6lax0x34napc2m7t5zdq6s7xxwpvk").unwrap();
     let bob = Bob::new(Btc::new(), Xmr, refund, fee_politic);
 
-    let pub_trade: PublicTrade =
+    let pub_trade: Deal =
         deserialize(&hex::decode(hex).unwrap()[..]).expect("Parsable public trade");
 
     (alice, bob, pub_trade)

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -26,7 +26,7 @@ use farcaster_core::crypto::{
     ArbitratingKeyId, CommitmentEngine, GenerateKey, ProveCrossGroupDleq,
 };
 use farcaster_core::protocol::message::*;
-use farcaster_core::swap::btcxmr::{Alice, Bob, Parameters, PublicOffer};
+use farcaster_core::swap::btcxmr::{Alice, Bob, Parameters, PublicTrade};
 use farcaster_core::swap::SwapId;
 use farcaster_core::transaction::*;
 
@@ -50,7 +50,7 @@ macro_rules! test_strict_ser {
     };
 }
 
-fn init() -> (Alice, Bob, PublicOffer) {
+fn init() -> (Alice, Bob, PublicTrade) {
     let hex = "46435357415001004450e567b1106f429247bb680e5fe0c80200000080800000800800a08601000\
                00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
@@ -62,15 +62,15 @@ fn init() -> (Alice, Bob, PublicOffer) {
     let refund = Address::from_str("bc1qesgvtyx9y6lax0x34napc2m7t5zdq6s7xxwpvk").unwrap();
     let bob = Bob::new(Btc::new(), Xmr, refund, fee_politic);
 
-    let pub_offer: PublicOffer =
-        deserialize(&hex::decode(hex).unwrap()[..]).expect("Parsable public offer");
+    let pub_trade: PublicTrade =
+        deserialize(&hex::decode(hex).unwrap()[..]).expect("Parsable public trade");
 
-    (alice, bob, pub_offer)
+    (alice, bob, pub_trade)
 }
 
 #[test]
 fn execute_offline_protocol() {
-    let (alice, bob, pub_offer) = init();
+    let (alice, bob, pub_trade) = init();
 
     let commitment_engine = CommitmentEngine;
     let mut alice_key_manager = KeyManager::new(
@@ -97,14 +97,14 @@ fn execute_offline_protocol() {
     // Commit/Reveal round
     //
     let alice_params: Parameters = alice
-        .generate_parameters(&mut alice_key_manager, &pub_offer)
+        .generate_parameters(&mut alice_key_manager, &pub_trade)
         .unwrap();
 
     let commit_alice_params = alice_params.commit_alice(swap_id, &commitment_engine);
     test_strict_ser!(commit_alice_params, CommitAliceParameters<KeccakCommitment>);
 
     let bob_params: Parameters = bob
-        .generate_parameters(&mut bob_key_manager, &pub_offer)
+        .generate_parameters(&mut bob_key_manager, &pub_trade)
         .unwrap();
     let commit_bob_params = bob_params.commit_bob(swap_id, &commitment_engine);
     test_strict_ser!(commit_bob_params, CommitBobParameters<KeccakCommitment>);
@@ -154,7 +154,7 @@ fn execute_offline_protocol() {
             &alice_params,
             &bob_params,
             funding,
-            pub_offer.to_arbitrating_params(),
+            pub_trade.to_arbitrating_params(),
         )
         .unwrap();
     let bob_cosign_cancel = bob
@@ -175,7 +175,7 @@ fn execute_offline_protocol() {
             &alice_params,
             &bob_params,
             &core,
-            pub_offer.to_arbitrating_params(),
+            pub_trade.to_arbitrating_params(),
         )
         .unwrap();
     let cancel_sig = alice
@@ -184,7 +184,7 @@ fn execute_offline_protocol() {
             &alice_params,
             &bob_params,
             &core,
-            pub_offer.to_arbitrating_params(),
+            pub_trade.to_arbitrating_params(),
         )
         .unwrap();
 
@@ -214,7 +214,7 @@ fn execute_offline_protocol() {
             &alice_params,
             &bob_params,
             &core,
-            pub_offer.to_arbitrating_params(),
+            pub_trade.to_arbitrating_params(),
         )
         .unwrap();
     let signed_lock = bob
@@ -243,7 +243,7 @@ fn execute_offline_protocol() {
             &alice_params,
             &bob_params,
             &core,
-            pub_offer.to_arbitrating_params(),
+            pub_trade.to_arbitrating_params(),
             &adaptor_buy,
         )
         .unwrap();
@@ -253,7 +253,7 @@ fn execute_offline_protocol() {
             &alice_params,
             &bob_params,
             &core,
-            pub_offer.to_arbitrating_params(),
+            pub_trade.to_arbitrating_params(),
             &adaptor_buy,
         )
         .unwrap();
@@ -357,7 +357,7 @@ fn execute_offline_protocol() {
             &alice_params,
             &bob_params,
             &core,
-            pub_offer.to_arbitrating_params(),
+            pub_trade.to_arbitrating_params(),
         )
         .unwrap();
 

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -62,15 +62,14 @@ fn init() -> (Alice, Bob, Deal) {
     let refund = Address::from_str("bc1qesgvtyx9y6lax0x34napc2m7t5zdq6s7xxwpvk").unwrap();
     let bob = Bob::new(Btc::new(), Xmr, refund, fee_politic);
 
-    let pub_trade: Deal =
-        deserialize(&hex::decode(hex).unwrap()[..]).expect("Parsable public trade");
+    let deal: Deal = deserialize(&hex::decode(hex).unwrap()[..]).expect("Parsable deal");
 
-    (alice, bob, pub_trade)
+    (alice, bob, deal)
 }
 
 #[test]
 fn execute_offline_protocol() {
-    let (alice, bob, pub_trade) = init();
+    let (alice, bob, deal) = init();
 
     let commitment_engine = CommitmentEngine;
     let mut alice_key_manager = KeyManager::new(
@@ -97,14 +96,14 @@ fn execute_offline_protocol() {
     // Commit/Reveal round
     //
     let alice_params: Parameters = alice
-        .generate_parameters(&mut alice_key_manager, &pub_trade)
+        .generate_parameters(&mut alice_key_manager, &deal)
         .unwrap();
 
     let commit_alice_params = alice_params.commit_alice(swap_id, &commitment_engine);
     test_strict_ser!(commit_alice_params, CommitAliceParameters<KeccakCommitment>);
 
     let bob_params: Parameters = bob
-        .generate_parameters(&mut bob_key_manager, &pub_trade)
+        .generate_parameters(&mut bob_key_manager, &deal)
         .unwrap();
     let commit_bob_params = bob_params.commit_bob(swap_id, &commitment_engine);
     test_strict_ser!(commit_bob_params, CommitBobParameters<KeccakCommitment>);
@@ -154,7 +153,7 @@ fn execute_offline_protocol() {
             &alice_params,
             &bob_params,
             funding,
-            pub_trade.to_arbitrating_params(),
+            deal.to_arbitrating_params(),
         )
         .unwrap();
     let bob_cosign_cancel = bob
@@ -175,7 +174,7 @@ fn execute_offline_protocol() {
             &alice_params,
             &bob_params,
             &core,
-            pub_trade.to_arbitrating_params(),
+            deal.to_arbitrating_params(),
         )
         .unwrap();
     let cancel_sig = alice
@@ -184,7 +183,7 @@ fn execute_offline_protocol() {
             &alice_params,
             &bob_params,
             &core,
-            pub_trade.to_arbitrating_params(),
+            deal.to_arbitrating_params(),
         )
         .unwrap();
 
@@ -214,7 +213,7 @@ fn execute_offline_protocol() {
             &alice_params,
             &bob_params,
             &core,
-            pub_trade.to_arbitrating_params(),
+            deal.to_arbitrating_params(),
         )
         .unwrap();
     let signed_lock = bob
@@ -243,7 +242,7 @@ fn execute_offline_protocol() {
             &alice_params,
             &bob_params,
             &core,
-            pub_trade.to_arbitrating_params(),
+            deal.to_arbitrating_params(),
             &adaptor_buy,
         )
         .unwrap();
@@ -253,7 +252,7 @@ fn execute_offline_protocol() {
             &alice_params,
             &bob_params,
             &core,
-            pub_trade.to_arbitrating_params(),
+            deal.to_arbitrating_params(),
             &adaptor_buy,
         )
         .unwrap();
@@ -357,7 +356,7 @@ fn execute_offline_protocol() {
             &alice_params,
             &bob_params,
             &core,
-            pub_trade.to_arbitrating_params(),
+            deal.to_arbitrating_params(),
         )
         .unwrap();
 

--- a/tests/trade.rs
+++ b/tests/trade.rs
@@ -20,7 +20,7 @@ use farcaster_core::blockchain::Blockchain;
 
 use farcaster_core::blockchain::{FeeStrategy, Network};
 use farcaster_core::consensus::{self, deserialize, serialize_hex};
-use farcaster_core::negotiation::{Offer, OfferFingerprint, PublicOffer};
+use farcaster_core::trade::{Offer, OfferFingerprint, PublicOffer};
 use farcaster_core::role::SwapRole;
 
 use bitcoin::Amount;

--- a/tests/trade.rs
+++ b/tests/trade.rs
@@ -21,7 +21,7 @@ use farcaster_core::blockchain::Blockchain;
 use farcaster_core::blockchain::{FeeStrategy, Network};
 use farcaster_core::consensus::{self, deserialize, serialize_hex};
 use farcaster_core::role::SwapRole;
-use farcaster_core::trade::{PublicTrade, Trade, TradeFingerprint};
+use farcaster_core::trade::{Deal, DealFingerprint, DealParameters};
 
 use bitcoin::Amount;
 use inet2_addr::InetSocketAddr;
@@ -33,23 +33,24 @@ use std::str::FromStr;
 fn create_trade() {
     let hex = "4450e567b1106f429247bb680e5fe0c802000000808000008008000500000000000000080006000000000000000400070000000400080000000\
                10800090000000000000002";
-    let trade: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> = Trade {
-        uuid: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
-        network: Network::Testnet,
-        arbitrating_blockchain: Blockchain::Bitcoin,
-        accordant_blockchain: Blockchain::Monero,
-        arbitrating_amount: Amount::from_sat(5),
-        accordant_amount: monero::Amount::from_pico(6),
-        cancel_timelock: CSVTimelock::new(7),
-        punish_timelock: CSVTimelock::new(8),
-        fee_strategy: FeeStrategy::Fixed(SatPerVByte::from_sat(9)),
-        maker_role: SwapRole::Bob,
-    };
+    let trade: DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+        DealParameters {
+            uuid: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
+            network: Network::Testnet,
+            arbitrating_blockchain: Blockchain::Bitcoin,
+            accordant_blockchain: Blockchain::Monero,
+            arbitrating_amount: Amount::from_sat(5),
+            accordant_amount: monero::Amount::from_pico(6),
+            cancel_timelock: CSVTimelock::new(7),
+            punish_timelock: CSVTimelock::new(8),
+            fee_strategy: FeeStrategy::Fixed(SatPerVByte::from_sat(9)),
+            maker_role: SwapRole::Bob,
+        };
 
     assert_eq!(hex, serialize_hex(&trade));
     let strict_ser = strict_encoding::strict_serialize(&trade).unwrap();
     assert_eq!(&hex::decode(hex).unwrap(), &strict_ser);
-    let res: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&strict_ser).unwrap();
     assert_eq!(&trade, &res);
 }
@@ -58,9 +59,9 @@ fn create_trade() {
 fn get_trade_fingerprint() {
     let hex = "4450e567b1106f429247bb680e5fe0c802000000808000008008000500000000000000080006000\
                00000000000040007000000040008000000010800090000000000000002";
-    let res: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&hex::decode(hex).unwrap()).unwrap();
-    let id = TradeFingerprint::from_str(
+    let id = DealFingerprint::from_str(
         "f79b29ccb233b37cea3aa35b94c5ece25c58a8098afc18f046810a3c04591599",
     )
     .unwrap();
@@ -68,7 +69,7 @@ fn get_trade_fingerprint() {
     // other uuid
     let hex = "4351e567b1106f429247bb680e5fe0c802000000808000008008000500000000000000080006000\
                00000000000040007000000040008000000010800090000000000000002";
-    let res: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&hex::decode(hex).unwrap()).unwrap();
     // same fingerprint
     assert_eq!(id, res.fingerprint());
@@ -78,7 +79,7 @@ fn get_trade_fingerprint() {
 fn get_trade_uuid() {
     let hex = "4450e567b1106f429247bb680e5fe0c802000000808000008008000500000000000000080006000\
                00000000000040007000000040008000000010800090000000000000002";
-    let res: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&hex::decode(hex).unwrap()).unwrap();
     assert_eq!(uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"), res.uuid());
 }
@@ -89,18 +90,19 @@ fn serialize_public_trade() {
                00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
                0000000000000000000000000000000000000000000000000000000260700";
-    let trade: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> = Trade {
-        uuid: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
-        network: Network::Testnet,
-        arbitrating_blockchain: Blockchain::Bitcoin,
-        accordant_blockchain: Blockchain::Monero,
-        arbitrating_amount: Amount::from_sat(100000),
-        accordant_amount: monero::Amount::from_pico(200),
-        cancel_timelock: CSVTimelock::new(10),
-        punish_timelock: CSVTimelock::new(10),
-        fee_strategy: FeeStrategy::Fixed(SatPerVByte::from_sat(20)),
-        maker_role: SwapRole::Bob,
-    };
+    let trade: DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+        DealParameters {
+            uuid: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
+            network: Network::Testnet,
+            arbitrating_blockchain: Blockchain::Bitcoin,
+            accordant_blockchain: Blockchain::Monero,
+            arbitrating_amount: Amount::from_sat(100000),
+            accordant_amount: monero::Amount::from_pico(200),
+            cancel_timelock: CSVTimelock::new(10),
+            punish_timelock: CSVTimelock::new(10),
+            fee_strategy: FeeStrategy::Fixed(SatPerVByte::from_sat(20)),
+            maker_role: SwapRole::Bob,
+        };
     let ip = FromStr::from_str("0.0.0.0").unwrap();
     let port = FromStr::from_str("9735").unwrap();
 
@@ -112,12 +114,12 @@ fn serialize_public_trade() {
     .inner;
     let node_id = secp256k1::PublicKey::from_secret_key(&secp, &sk);
     let peer_address = InetSocketAddr::socket(ip, port);
-    let public_trade = trade.to_public_v1(node_id, peer_address);
+    let public_trade = trade.to_v1(node_id, peer_address);
 
     assert_eq!(hex, serialize_hex(&public_trade));
     let strict_ser = strict_encoding::strict_serialize(&public_trade).unwrap();
     assert_eq!(&hex::decode(hex).unwrap(), &strict_ser);
-    let res: PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: Deal<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&strict_ser).unwrap();
     assert_eq!(&public_trade, &res);
 }
@@ -128,9 +130,9 @@ fn get_public_trade_fingerprint() {
                00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
                0000000000000000000000000000000000000000000000000000000260700";
-    let res: PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: Deal<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&hex::decode(hex).unwrap()).unwrap();
-    let id = TradeFingerprint::from_str(
+    let id = DealFingerprint::from_str(
         "3a466a0a0cff7bf800808653460076549621d07db78e697b9dfaebaba0ab8b33",
     )
     .unwrap();
@@ -140,7 +142,7 @@ fn get_public_trade_fingerprint() {
                00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
                0000000000000000000000000000000000000000000000000000000260700";
-    let res: PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: Deal<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&hex::decode(hex).unwrap()).unwrap();
     // same fingerprint
     assert_eq!(id, res.fingerprint());
@@ -152,7 +154,7 @@ fn get_public_trade_uuid() {
                00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
                0000000000000000000000000000000000000000000000000000000260700";
-    let res: PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: Deal<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&hex::decode(hex).unwrap()).unwrap();
     assert_eq!(uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"), res.uuid());
 }
@@ -164,7 +166,7 @@ fn check_public_trade_magic_bytes() {
                  03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
                  0000000000000000000000000000000000000000000000000000000260700";
     let pub_trade: Result<
-        PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>,
+        Deal<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>,
         consensus::Error,
     > = deserialize(&hex::decode(valid).unwrap()[..]);
     assert!(pub_trade.is_ok());
@@ -174,7 +176,7 @@ fn check_public_trade_magic_bytes() {
                  03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
                  0000000000000000000000000000000000000000000000000000000260700";
     let pub_trade: Result<
-        PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>,
+        Deal<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>,
         consensus::Error,
     > = deserialize(&hex::decode(invalid).unwrap()[..]);
     assert!(pub_trade.is_err());
@@ -191,7 +193,7 @@ fn parse_public_trade() {
     .iter_mut()
     {
         let bytes = hex::decode(hex).expect("hex");
-        let res: Result<PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>, _> =
+        let res: Result<Deal<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>, _> =
             strict_encoding::strict_deserialize(&bytes);
         assert!(res.is_ok());
     }

--- a/tests/trade.rs
+++ b/tests/trade.rs
@@ -30,10 +30,10 @@ use uuid::uuid;
 use std::str::FromStr;
 
 #[test]
-fn create_trade() {
+fn create_deal_parameters() {
     let hex = "4450e567b1106f429247bb680e5fe0c802000000808000008008000500000000000000080006000000000000000400070000000400080000000\
                10800090000000000000002";
-    let trade: DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let deal: DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         DealParameters {
             uuid: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
             network: Network::Testnet,
@@ -47,16 +47,16 @@ fn create_trade() {
             maker_role: SwapRole::Bob,
         };
 
-    assert_eq!(hex, serialize_hex(&trade));
-    let strict_ser = strict_encoding::strict_serialize(&trade).unwrap();
+    assert_eq!(hex, serialize_hex(&deal));
+    let strict_ser = strict_encoding::strict_serialize(&deal).unwrap();
     assert_eq!(&hex::decode(hex).unwrap(), &strict_ser);
     let res: DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&strict_ser).unwrap();
-    assert_eq!(&trade, &res);
+    assert_eq!(&deal, &res);
 }
 
 #[test]
-fn get_trade_fingerprint() {
+fn get_deal_parameters_fingerprint() {
     let hex = "4450e567b1106f429247bb680e5fe0c802000000808000008008000500000000000000080006000\
                00000000000040007000000040008000000010800090000000000000002";
     let res: DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
@@ -76,7 +76,7 @@ fn get_trade_fingerprint() {
 }
 
 #[test]
-fn get_trade_uuid() {
+fn get_deal_parameters_uuid() {
     let hex = "4450e567b1106f429247bb680e5fe0c802000000808000008008000500000000000000080006000\
                00000000000040007000000040008000000010800090000000000000002";
     let res: DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
@@ -85,12 +85,12 @@ fn get_trade_uuid() {
 }
 
 #[test]
-fn serialize_public_trade() {
+fn serialize_deal() {
     let hex = "46435357415001004450e567b1106f429247bb680e5fe0c80200000080800000800800a08601000\
                00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
                0000000000000000000000000000000000000000000000000000000260700";
-    let trade: DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let deal: DealParameters<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         DealParameters {
             uuid: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
             network: Network::Testnet,
@@ -114,18 +114,18 @@ fn serialize_public_trade() {
     .inner;
     let node_id = secp256k1::PublicKey::from_secret_key(&secp, &sk);
     let peer_address = InetSocketAddr::socket(ip, port);
-    let public_trade = trade.to_v1(node_id, peer_address);
+    let deal = deal.to_v1(node_id, peer_address);
 
-    assert_eq!(hex, serialize_hex(&public_trade));
-    let strict_ser = strict_encoding::strict_serialize(&public_trade).unwrap();
+    assert_eq!(hex, serialize_hex(&deal));
+    let strict_ser = strict_encoding::strict_serialize(&deal).unwrap();
     assert_eq!(&hex::decode(hex).unwrap(), &strict_ser);
     let res: Deal<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&strict_ser).unwrap();
-    assert_eq!(&public_trade, &res);
+    assert_eq!(&deal, &res);
 }
 
 #[test]
-fn get_public_trade_fingerprint() {
+fn get_deal_fingerprint() {
     let hex = "46435357415001004450e567b1106f429247bb680e5fe0c80200000080800000800800a08601000\
                00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
@@ -149,7 +149,7 @@ fn get_public_trade_fingerprint() {
 }
 
 #[test]
-fn get_public_trade_uuid() {
+fn get_deal_uuid() {
     let hex = "46435357415001004450e567b1106f429247bb680e5fe0c80200000080800000800800a08601000\
                00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
@@ -160,30 +160,30 @@ fn get_public_trade_uuid() {
 }
 
 #[test]
-fn check_public_trade_magic_bytes() {
+fn check_deal_magic_bytes() {
     let valid = "46435357415001004450e567b1106f429247bb680e5fe0c80200000080800000800800a08601000\
                  00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                  03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
                  0000000000000000000000000000000000000000000000000000000260700";
-    let pub_trade: Result<
+    let deal: Result<
         Deal<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>,
         consensus::Error,
     > = deserialize(&hex::decode(valid).unwrap()[..]);
-    assert!(pub_trade.is_ok());
+    assert!(deal.is_ok());
 
     let invalid = "47435357415001004450e567b1106f429247bb680e5fe0c80200000080800000800800a08601000\
                  00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                  03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
                  0000000000000000000000000000000000000000000000000000000260700";
-    let pub_trade: Result<
+    let deal: Result<
         Deal<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>,
         consensus::Error,
     > = deserialize(&hex::decode(invalid).unwrap()[..]);
-    assert!(pub_trade.is_err());
+    assert!(deal.is_err());
 }
 
 #[test]
-fn parse_public_trade() {
+fn parse_deal() {
     for hex in [
         "46435357415001004450e567b1106f429247bb680e5fe0c80200000080800000800800a08601000\
          00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\

--- a/tests/trade.rs
+++ b/tests/trade.rs
@@ -20,8 +20,8 @@ use farcaster_core::blockchain::Blockchain;
 
 use farcaster_core::blockchain::{FeeStrategy, Network};
 use farcaster_core::consensus::{self, deserialize, serialize_hex};
-use farcaster_core::trade::{Offer, OfferFingerprint, PublicOffer};
 use farcaster_core::role::SwapRole;
+use farcaster_core::trade::{PublicTrade, Trade, TradeFingerprint};
 
 use bitcoin::Amount;
 use inet2_addr::InetSocketAddr;
@@ -30,10 +30,10 @@ use uuid::uuid;
 use std::str::FromStr;
 
 #[test]
-fn create_offer() {
+fn create_trade() {
     let hex = "4450e567b1106f429247bb680e5fe0c802000000808000008008000500000000000000080006000000000000000400070000000400080000000\
                10800090000000000000002";
-    let offer: Offer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> = Offer {
+    let trade: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> = Trade {
         uuid: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
         network: Network::Testnet,
         arbitrating_blockchain: Blockchain::Bitcoin,
@@ -46,21 +46,21 @@ fn create_offer() {
         maker_role: SwapRole::Bob,
     };
 
-    assert_eq!(hex, serialize_hex(&offer));
-    let strict_ser = strict_encoding::strict_serialize(&offer).unwrap();
+    assert_eq!(hex, serialize_hex(&trade));
+    let strict_ser = strict_encoding::strict_serialize(&trade).unwrap();
     assert_eq!(&hex::decode(hex).unwrap(), &strict_ser);
-    let res: Offer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&strict_ser).unwrap();
-    assert_eq!(&offer, &res);
+    assert_eq!(&trade, &res);
 }
 
 #[test]
-fn get_offer_fingerprint() {
+fn get_trade_fingerprint() {
     let hex = "4450e567b1106f429247bb680e5fe0c802000000808000008008000500000000000000080006000\
                00000000000040007000000040008000000010800090000000000000002";
-    let res: Offer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&hex::decode(hex).unwrap()).unwrap();
-    let id = OfferFingerprint::from_str(
+    let id = TradeFingerprint::from_str(
         "f79b29ccb233b37cea3aa35b94c5ece25c58a8098afc18f046810a3c04591599",
     )
     .unwrap();
@@ -68,28 +68,28 @@ fn get_offer_fingerprint() {
     // other uuid
     let hex = "4351e567b1106f429247bb680e5fe0c802000000808000008008000500000000000000080006000\
                00000000000040007000000040008000000010800090000000000000002";
-    let res: Offer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&hex::decode(hex).unwrap()).unwrap();
     // same fingerprint
     assert_eq!(id, res.fingerprint());
 }
 
 #[test]
-fn get_offer_uuid() {
+fn get_trade_uuid() {
     let hex = "4450e567b1106f429247bb680e5fe0c802000000808000008008000500000000000000080006000\
                00000000000040007000000040008000000010800090000000000000002";
-    let res: Offer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&hex::decode(hex).unwrap()).unwrap();
     assert_eq!(uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"), res.uuid());
 }
 
 #[test]
-fn serialize_public_offer() {
+fn serialize_public_trade() {
     let hex = "46435357415001004450e567b1106f429247bb680e5fe0c80200000080800000800800a08601000\
                00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
                0000000000000000000000000000000000000000000000000000000260700";
-    let offer: Offer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> = Offer {
+    let trade: Trade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> = Trade {
         uuid: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
         network: Network::Testnet,
         arbitrating_blockchain: Blockchain::Bitcoin,
@@ -112,25 +112,25 @@ fn serialize_public_offer() {
     .inner;
     let node_id = secp256k1::PublicKey::from_secret_key(&secp, &sk);
     let peer_address = InetSocketAddr::socket(ip, port);
-    let public_offer = offer.to_public_v1(node_id, peer_address);
+    let public_trade = trade.to_public_v1(node_id, peer_address);
 
-    assert_eq!(hex, serialize_hex(&public_offer));
-    let strict_ser = strict_encoding::strict_serialize(&public_offer).unwrap();
+    assert_eq!(hex, serialize_hex(&public_trade));
+    let strict_ser = strict_encoding::strict_serialize(&public_trade).unwrap();
     assert_eq!(&hex::decode(hex).unwrap(), &strict_ser);
-    let res: PublicOffer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&strict_ser).unwrap();
-    assert_eq!(&public_offer, &res);
+    assert_eq!(&public_trade, &res);
 }
 
 #[test]
-fn get_public_offer_fingerprint() {
+fn get_public_trade_fingerprint() {
     let hex = "46435357415001004450e567b1106f429247bb680e5fe0c80200000080800000800800a08601000\
                00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
                0000000000000000000000000000000000000000000000000000000260700";
-    let res: PublicOffer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&hex::decode(hex).unwrap()).unwrap();
-    let id = OfferFingerprint::from_str(
+    let id = TradeFingerprint::from_str(
         "3a466a0a0cff7bf800808653460076549621d07db78e697b9dfaebaba0ab8b33",
     )
     .unwrap();
@@ -140,48 +140,48 @@ fn get_public_offer_fingerprint() {
                00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
                0000000000000000000000000000000000000000000000000000000260700";
-    let res: PublicOffer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&hex::decode(hex).unwrap()).unwrap();
     // same fingerprint
     assert_eq!(id, res.fingerprint());
 }
 
 #[test]
-fn get_public_offer_uuid() {
+fn get_public_trade_uuid() {
     let hex = "46435357415001004450e567b1106f429247bb680e5fe0c80200000080800000800800a08601000\
                00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
                0000000000000000000000000000000000000000000000000000000260700";
-    let res: PublicOffer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
+    let res: PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte> =
         strict_encoding::strict_deserialize(&hex::decode(hex).unwrap()).unwrap();
     assert_eq!(uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"), res.uuid());
 }
 
 #[test]
-fn check_public_offer_magic_bytes() {
+fn check_public_trade_magic_bytes() {
     let valid = "46435357415001004450e567b1106f429247bb680e5fe0c80200000080800000800800a08601000\
                  00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                  03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
                  0000000000000000000000000000000000000000000000000000000260700";
-    let pub_offer: Result<
-        PublicOffer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>,
+    let pub_trade: Result<
+        PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>,
         consensus::Error,
     > = deserialize(&hex::decode(valid).unwrap()[..]);
-    assert!(pub_offer.is_ok());
+    assert!(pub_trade.is_ok());
 
     let invalid = "47435357415001004450e567b1106f429247bb680e5fe0c80200000080800000800800a08601000\
                  00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
                  03b31a0a70343bb46f3db3768296ac5027f9873921b37f852860c690063ff9e4c90000000000000\
                  0000000000000000000000000000000000000000000000000000000260700";
-    let pub_offer: Result<
-        PublicOffer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>,
+    let pub_trade: Result<
+        PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>,
         consensus::Error,
     > = deserialize(&hex::decode(invalid).unwrap()[..]);
-    assert!(pub_offer.is_err());
+    assert!(pub_trade.is_err());
 }
 
 #[test]
-fn parse_public_offer() {
+fn parse_public_trade() {
     for hex in [
         "46435357415001004450e567b1106f429247bb680e5fe0c80200000080800000800800a08601000\
          00000000800c80000000000000004000a00000004000a0000000108001400000000000000022100\
@@ -191,7 +191,7 @@ fn parse_public_offer() {
     .iter_mut()
     {
         let bytes = hex::decode(hex).expect("hex");
-        let res: Result<PublicOffer<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>, _> =
+        let res: Result<PublicTrade<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>, _> =
             strict_encoding::strict_deserialize(&bytes);
         assert!(res.is_ok());
     }


### PR DESCRIPTION
`Offer` and `negotiation` are misleading as they are used to initialized a swap more than to negotiate a trade. To separate the current ambiguity we move completely to `trade` terminology to allow `negotiation` and `offer` to fulfill their roles later.

Also the negotiation is not part of the minimum stack and does not require to be inside _core_ (nor even _node_), this can be left to other implementations.

**EDIT**

`farcaster_core::negotiation` becomes `farcaster_core::trade`
`Offer` becomes `DealParameters`
`PublicOffer` becomes `Deal`