### PR TITLE
Fix: check len when parsing deals from str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Check input lenght when parsing deals from strings by @h4sh3d ([#313](https://github.com/farcaster-project/farcaster-core/pull/313)])
+
 ## [0.6.1] - 2022-12-14
 
 ### Added

--- a/src/trade.rs
+++ b/src/trade.rs
@@ -473,6 +473,9 @@ where
     type Err = consensus::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() < 6 {
+            return Err(consensus::Error::UnknownType);
+        }
         if &s[..5] != DEAL_PREFIX {
             return Err(consensus::Error::IncorrectMagicBytes);
         }
@@ -576,6 +579,16 @@ mod tests {
                 maker_role: SwapRole::Bob,
             }
         };
+    }
+
+    #[test]
+    fn parse_invalid_deal() {
+        for deal in ["", "D", "Deal", "Deal:", "Deal:a", "Deal:aa"] {
+            assert!(
+                Deal::<bitcoin::Amount, monero::Amount, CSVTimelock, SatPerVByte>::from_str(deal)
+                    .is_err()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #310

User can input any string, check that we have enough chars to split the str in two parts, otherwise it's not a deal.