### PR TITLE
Feat: add fee range under crate feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,9 @@ jobs:
         ]
         include:
         - rust: stable
-          features: default
+          features: default,fee_range
         - rust: nightly
-          features: default,nightly
+          features: default,fee_range,nightly
 
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fee strategy `range` support is now under the new crate feature `fee_range` and disable by default ([#314](https://github.com/farcaster-project/farcaster-core/pull/314))
+
 ### Fixed
 
 - Check input lenght when parsing deals from strings by @h4sh3d ([#313](https://github.com/farcaster-project/farcaster-core/pull/313)])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rpc = []
 experimental = ["ecdsa_fun", "secp256kfun", "rand", "sha2", "rand_chacha", "bincode"]
 taproot = []
 nightly = []
+fee_range = []
 
 default = ["experimental", "taproot"]
 

--- a/src/bitcoin/fee.rs
+++ b/src/bitcoin/fee.rs
@@ -159,6 +159,7 @@ impl Fee for PartiallySignedTransaction {
     type Amount = Amount;
 
     /// Calculates and sets the fees on the given transaction and return the fees set
+    #[allow(unused_variables)]
     fn set_fee(
         &mut self,
         strategy: &FeeStrategy<SatPerVByte>,
@@ -185,6 +186,7 @@ impl Fee for PartiallySignedTransaction {
         // Compute the fee amount to set in total
         let fee_amount = match strategy {
             FeeStrategy::Fixed(sat_per_vbyte) => sat_per_vbyte.as_native_unit().checked_mul(weight),
+            #[cfg(feature = "fee_range")]
             FeeStrategy::Range { min_inc, max_inc } => match politic {
                 FeePriority::Low => min_inc.as_native_unit().checked_mul(weight),
                 FeePriority::High => max_inc.as_native_unit().checked_mul(weight),


### PR DESCRIPTION
Fix  #312

A new feature `fee_range` is added to the crate (disable by default) so we can remove the support in node and add it back when we want.