### PR TITLE
Refactor(KeyManager): Don't persist master secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Implement `From<trade::DealId>` and `From<swap::SwapId>` for `Uuid` by @h4sh3d ([#323](https://github.com/farcaster-project/farcaster-core/pull/323))
 
+### Changed
+
+- Don't persist master secret key in `KeyManager` and derive account level keys on initialization by @TheCharlatan ([#322](https://github.com/farcaster-project/farcaster-core/pull/322))
+
 ## [0.6.3] - 2022-12-28
 
 ### Added

--- a/src/swap/btcxmr.rs
+++ b/src/swap/btcxmr.rs
@@ -188,14 +188,12 @@ impl Derivation for SharedKeyId {
 /// handling [`GenerateKey`], [`GenerateSharedKey`] and [`Sign`].
 #[derive(Clone, Debug)]
 pub struct KeyManager {
-    /// The master 32-bytes seed used to derive all the keys for all the swaps.
-    master_seed: [u8; 32],
     /// The swap identifier used in the derivation.
     swap_index: ChildNumber,
-    /// The master secp256k1 seed.
-    bitcoin_master_key: Secp256k1ExtSecretKey,
-    /// The master ed25519 seed.
-    monero_master_key: Ed25519ExtSecretKey,
+    /// The secp256k1 account key as derived from swap_index.
+    bitcoin_account_key: Secp256k1ExtSecretKey,
+    /// The ed25519 account key as derived from swap_index.
+    monero_account_key: Ed25519ExtSecretKey,
     /// A list of already derived keys for secp256k1 by derivation path.
     bitcoin_derivations: HashMap<DerivationPath, SecretKey>,
     /// A list of already derived monero keys for ed25519 by derivation path.
@@ -204,8 +202,9 @@ pub struct KeyManager {
 
 impl Encodable for KeyManager {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
-        let mut len = self.master_seed.consensus_encode(writer)?;
-        len += Into::<u32>::into(self.swap_index).consensus_encode(writer)?;
+        let mut len = Into::<u32>::into(self.swap_index).consensus_encode(writer)?;
+        len += self.bitcoin_account_key.consensus_encode(writer)?;
+        len += self.monero_account_key.consensus_encode(writer)?;
         // TODO: don't add derivations, but test that key manager encoding is correct modulo cached derivations
         Ok(len)
     }
@@ -213,13 +212,13 @@ impl Encodable for KeyManager {
 
 impl Decodable for KeyManager {
     fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
-        let master_seed = Decodable::consensus_decode(d)?;
         let swap_index: u32 = Decodable::consensus_decode(d)?;
+        let bitcoin_account_key = Secp256k1ExtSecretKey::consensus_decode(d)?;
+        let monero_account_key = Ed25519ExtSecretKey::consensus_decode(d)?;
         Ok(KeyManager {
-            master_seed,
             swap_index: ChildNumber::from(swap_index),
-            bitcoin_master_key: Secp256k1ExtSecretKey::new_master(master_seed.as_ref()),
-            monero_master_key: Ed25519ExtSecretKey::new_master(master_seed.as_ref()),
+            bitcoin_account_key,
+            monero_account_key,
             bitcoin_derivations: HashMap::new(),
             monero_derivations: HashMap::new(),
         })
@@ -227,16 +226,14 @@ impl Decodable for KeyManager {
 }
 
 impl KeyManager {
-    /// Generate the derivation path of a key, computed as:
-    /// `m/44'/{blockchain}'/{swap_index}'/{key_type}'/{key_idx}'`.
-    pub fn get_derivation_path(
-        &self,
+    /// Generate the derivation path of an account key, computed as:
+    /// `m/44'/{blockchain}'/{swap_index}'`.
+    pub fn get_account_derivation_path(
         blockchain: Blockchain,
-        key_id: impl Derivation,
+        swap_index: ChildNumber,
     ) -> Result<DerivationPath, crypto::Error> {
         let path = blockchain.derivation_path()?;
-        let path = path.extend([self.swap_index]);
-        Ok(path.extend(&key_id.derivation_path()?))
+        Ok(path.extend([swap_index]))
     }
 
     /// Try to retreive the secret key internally if already generated, if the key is not found
@@ -245,7 +242,7 @@ impl KeyManager {
         &mut self,
         key_id: impl Derivation,
     ) -> Result<SecretKey, crypto::Error> {
-        let path = self.get_derivation_path(Blockchain::Bitcoin, key_id)?;
+        let path = key_id.derivation_path()?;
         self.bitcoin_derivations
             .get(&path)
             // Option<Result<SecretKey, _>>
@@ -254,7 +251,7 @@ impl KeyManager {
             // None => || { ... } => Result<SecretKey, crypto::Error>
             .unwrap_or_else(|| {
                 let secp = Secp256k1::new();
-                match self.bitcoin_master_key.derive_priv(&secp, &path) {
+                match self.bitcoin_account_key.derive_priv(&secp, &path) {
                     Ok(key) => {
                         self.bitcoin_derivations.insert(path, key.secret_key);
                         Ok(key.secret_key)
@@ -270,7 +267,7 @@ impl KeyManager {
         &mut self,
         key_id: impl Derivation,
     ) -> Result<monero::PrivateKey, crypto::Error> {
-        let path = self.get_derivation_path(Blockchain::Monero, key_id)?;
+        let path = key_id.derivation_path()?;
         self.monero_derivations
             .get(&path)
             // Option<Result<PrivateKey, _>>
@@ -279,7 +276,7 @@ impl KeyManager {
             // None => || { ... } => Result<PrivateKey, crypto::Error>
             .unwrap_or_else(|| {
                 let key_seed = self
-                    .monero_master_key
+                    .monero_account_key
                     .derive_priv(&path)
                     .expect("Path does not contain non-hardened derivation")
                     .secret_key;
@@ -304,11 +301,17 @@ impl KeyManager {
     /// Create a new key manager with the provided master seed, returns an error if the swap index is
     /// not within `[0, 2^31 - 1]`.
     pub fn new(seed: [u8; 32], swap_index: u32) -> Result<Self, crypto::Error> {
+        let swap_index = ChildNumber::from_hardened_idx(swap_index).map_err(crypto::Error::new)?;
+        let secp = Secp256k1::new();
         Ok(Self {
-            master_seed: seed,
-            swap_index: ChildNumber::from_hardened_idx(swap_index).map_err(crypto::Error::new)?,
-            bitcoin_master_key: Secp256k1ExtSecretKey::new_master(seed.as_ref()),
-            monero_master_key: Ed25519ExtSecretKey::new_master(seed.as_ref()),
+            swap_index,
+            bitcoin_account_key: Secp256k1ExtSecretKey::new_master(seed.as_ref()).derive_priv(
+                &secp,
+                &Self::get_account_derivation_path(Blockchain::Bitcoin, swap_index)?,
+            )?,
+            monero_account_key: Ed25519ExtSecretKey::new_master(seed.as_ref()).derive_priv(
+                &Self::get_account_derivation_path(Blockchain::Monero, swap_index)?,
+            )?,
             bitcoin_derivations: HashMap::new(),
             monero_derivations: HashMap::new(),
         })


### PR DESCRIPTION
Derive account level keys on initialization.

This has the benefit of informationally segregating instantiated key manager.

Since the swap index is not mutable, every swap has to instantiate its own key manager. In order to informationally guarantee that each swap can only read and reach keys with its own swap index, derive the keys to the account index on key manager generation.

This is the last piece of the puzzle of the swap/wallet refactor that I discussed with @Lederstrumpf .