### PR TITLE
Feat: add from deal and swap ids for uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Derive strict encoding for FundingTx (segwit v0) by @TheCharlatan
-  ([#320](https://github.com/farcaster-project/farcaster-core/pull/320/files))
+- Derive strict encoding for FundingTx (segwit v0) by @TheCharlatan ([#320](https://github.com/farcaster-project/farcaster-core/pull/320/files))
 
 ## [0.6.2] - 2022-12-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Implement `From<trade::DealId>` and `From<swap::SwapId>` for `Uuid` by @h4sh3d ([#323](https://github.com/farcaster-project/farcaster-core/pull/323))
+
 ## [0.6.3] - 2022-12-28
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,18 @@ impl From<uuid::Uuid> for Uuid {
     }
 }
 
+impl From<trade::DealId> for Uuid {
+    fn from(id: trade::DealId) -> Self {
+        id.0
+    }
+}
+
+impl From<swap::SwapId> for Uuid {
+    fn from(id: swap::SwapId) -> Self {
+        id.0
+    }
+}
+
 impl FromStr for Uuid {
     type Err = uuid::Error;
 


### PR DESCRIPTION
Our wrapper `Uuid` can now be retrieved with `dealid.into()` and `swapid.into()`