### PR TITLE
Refactor: rename DoubleKeys into SwapRoleKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Don't persist master secret key in `KeyManager` and derive account level keys on initialization by @TheCharlatan ([#322](https://github.com/farcaster-project/farcaster-core/pull/322))
+- Rename `DoubleKeys` into `SwapRoleKeys` by @h4sh3d ([#324](https://github.com/farcaster-project/farcaster-core/pull/324))
 
 ## [0.6.3] - 2022-12-28
 

--- a/src/bitcoin/segwitv0.rs
+++ b/src/bitcoin/segwitv0.rs
@@ -32,7 +32,7 @@ use crate::blockchain::Transactions;
 use crate::consensus::{self, CanonicalBytes};
 use crate::crypto::{DeriveKeys, SharedKeyId};
 use crate::role::SwapRole;
-use crate::script::{DataLock, DataPunishableLock, DoubleKeys, ScriptPath};
+use crate::script::{DataLock, DataPunishableLock, ScriptPath, SwapRoleKeys};
 
 use bitcoin::blockdata::opcodes;
 use bitcoin::blockdata::script::{Builder, Instruction, Script};
@@ -106,7 +106,7 @@ pub struct CoopLock {
 impl CoopLock {
     pub fn script(data: DataLock<CSVTimelock, PublicKey>) -> Script {
         let DataLock {
-            success: DoubleKeys { alice, bob },
+            success: SwapRoleKeys { alice, bob },
             ..
         } = data;
         Builder::new()
@@ -198,7 +198,7 @@ impl PunishLock {
     pub fn script(data: DataPunishableLock<CSVTimelock, PublicKey>) -> Script {
         let DataPunishableLock {
             timelock,
-            success: DoubleKeys { alice, bob },
+            success: SwapRoleKeys { alice, bob },
             failure,
         } = data;
         Builder::new()

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -33,7 +33,7 @@ use crate::protocol::message::{
     BuyProcedureSignature, CommitAliceParameters, CommitBobParameters, CoreArbitratingSetup,
     RevealAliceParameters, RevealBobParameters,
 };
-use crate::script::{DataLock, DataPunishableLock, DoubleKeys, ScriptPath};
+use crate::script::{DataLock, DataPunishableLock, ScriptPath, SwapRoleKeys};
 use crate::swap::SwapId;
 use crate::trade::Deal;
 use crate::transaction::{
@@ -917,8 +917,8 @@ where
         // arbitrating blockchain.
         let data_lock = DataLock {
             timelock: arb_params.cancel_timelock,
-            success: DoubleKeys::new(alice_buy, bob_buy),
-            failure: DoubleKeys::new(alice_cancel, bob_cancel),
+            success: SwapRoleKeys::new(alice_buy, bob_buy),
+            failure: SwapRoleKeys::new(alice_cancel, bob_cancel),
         };
 
         // Verify the lock transaction template.
@@ -944,7 +944,7 @@ where
         // arbitrating blockchain.
         let punish_lock = DataPunishableLock {
             timelock: arb_params.punish_timelock,
-            success: DoubleKeys::new(alice_refund, bob_refund),
+            success: SwapRoleKeys::new(alice_refund, bob_refund),
             failure: alice_punish,
         };
 
@@ -1209,8 +1209,8 @@ where
         // arbitrating blockchain.
         let cancel_lock = DataLock {
             timelock: arb_params.cancel_timelock,
-            success: DoubleKeys::new(alice_buy, bob_buy),
-            failure: DoubleKeys::new(alice_cancel, bob_cancel),
+            success: SwapRoleKeys::new(alice_buy, bob_buy),
+            failure: SwapRoleKeys::new(alice_cancel, bob_cancel),
         };
 
         // The target amount is dictated from the deal.
@@ -1236,7 +1236,7 @@ where
         // arbitrating blockchain.
         let punish_lock = DataPunishableLock {
             timelock: arb_params.punish_timelock,
-            success: DoubleKeys::new(alice_refund, bob_refund),
+            success: SwapRoleKeys::new(alice_refund, bob_refund),
             failure: alice_punish,
         };
 
@@ -1444,8 +1444,8 @@ where
         // arbitrating blockchain.
         let cancel_lock = DataLock {
             timelock: arb_params.cancel_timelock,
-            success: DoubleKeys::new(alice_buy, bob_buy),
-            failure: DoubleKeys::new(alice_cancel, bob_cancel),
+            success: SwapRoleKeys::new(alice_buy, bob_buy),
+            failure: SwapRoleKeys::new(alice_cancel, bob_cancel),
         };
 
         // Initialize the buy transaction based on the lock and the data lock. The buy transaction

--- a/src/script.rs
+++ b/src/script.rs
@@ -22,21 +22,21 @@ use std::fmt;
 ///
 /// [`SwapRole`]: crate::role::SwapRole
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct DoubleKeys<Pk> {
+pub struct SwapRoleKeys<Pk> {
     /// Public key associated to Alice swap role.
     pub alice: Pk,
     /// Public key associated to Bob swap role.
     pub bob: Pk,
 }
 
-impl<Pk> DoubleKeys<Pk> {
+impl<Pk> SwapRoleKeys<Pk> {
     /// Store public keys for swap participant.
     pub fn new(alice: Pk, bob: Pk) -> Self {
         Self { alice, bob }
     }
 }
 
-impl<Pk> fmt::Display for DoubleKeys<Pk>
+impl<Pk> fmt::Display for SwapRoleKeys<Pk>
 where
     Pk: fmt::Display,
 {
@@ -63,8 +63,8 @@ pub enum ScriptPath {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct DataLock<Ti, Pk> {
     pub timelock: Ti,
-    pub success: DoubleKeys<Pk>,
-    pub failure: DoubleKeys<Pk>,
+    pub success: SwapRoleKeys<Pk>,
+    pub failure: SwapRoleKeys<Pk>,
 }
 
 impl<Ti, Pk> fmt::Display for DataLock<Ti, Pk>
@@ -89,7 +89,7 @@ where
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct DataPunishableLock<Ti, Pk> {
     pub timelock: Ti,
-    pub success: DoubleKeys<Pk>,
+    pub success: SwapRoleKeys<Pk>,
     pub failure: Pk,
 }
 
@@ -120,7 +120,7 @@ mod tests {
             0xc9, 0x62, 0x67, 0x90, 0x63,
         ])
         .expect("public keys must be 33 or 65 bytes, serialized according to SEC 2");
-        let double_key = DoubleKeys::<PublicKey>::new(public_key, public_key);
+        let double_key = SwapRoleKeys::<PublicKey>::new(public_key, public_key);
         let s = serde_yaml::to_string(&double_key).unwrap();
         let yml = r#"---
 alice: 02c66e7d8966b5c555af5805989da9fbf8db95e15631ce358c3a1710c962679063

--- a/tests/transactions.rs
+++ b/tests/transactions.rs
@@ -79,8 +79,8 @@ macro_rules! setup_txs {
 
         let datalock = DataLock {
             timelock: timelock::CSVTimelock::new(10),
-            success: DoubleKeys::new(pubkey_a1, pubkey_b1),
-            failure: DoubleKeys::new(pubkey_a1, pubkey_b1),
+            success: SwapRoleKeys::new(pubkey_a1, pubkey_b1),
+            failure: SwapRoleKeys::new(pubkey_a1, pubkey_b1),
         };
 
         let fee = FeeStrategy::Fixed(SatPerKvB::from_sat(1500));
@@ -93,7 +93,7 @@ macro_rules! setup_txs {
         //
         let datapunishablelock = DataPunishableLock {
             timelock: timelock::CSVTimelock::new(10),
-            success: DoubleKeys::new(pubkey_a1, pubkey_b1),
+            success: SwapRoleKeys::new(pubkey_a1, pubkey_b1),
             failure: pubkey_a1,
         };
 


### PR DESCRIPTION
Closes #254, swap role keys is more appropriate as this struct holds one public key per swap role.