### PR TITLE
Refactor: unify protocol reveal params and proof messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't persist master secret key in `KeyManager` and derive account level keys on initialization by @TheCharlatan ([#322](https://github.com/farcaster-project/farcaster-core/pull/322))
 - Rename `DoubleKeys` into `SwapRoleKeys` by @h4sh3d ([#324](https://github.com/farcaster-project/farcaster-core/pull/324))
 
+### Removed
+
+- Stand alone reveal proof message is removed and part of Alice and Bob reveal parameters by @h4sh3d ([#325](https://github.com/farcaster-project/farcaster-core/pull/325))
+
 ## [0.6.3] - 2022-12-28
 
 ### Added

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -294,7 +294,7 @@ where
     pub fn reveal_alice<U: Into<SwapId>>(
         self,
         swap_id: U,
-    ) -> RevealAliceParameters<Pk, Qk, Rk, Sk, Addr> {
+    ) -> RevealAliceParameters<Pk, Qk, Rk, Sk, Addr, Pr> {
         RevealAliceParameters {
             swap_id: swap_id.into(),
             buy: self.buy,
@@ -308,6 +308,7 @@ where
             extra_accordant_keys: self.extra_accordant_keys,
             accordant_shared_keys: self.accordant_shared_keys,
             address: self.destination_address,
+            proof: self.proof.expect("Generated parameters contains proof"),
         }
     }
 
@@ -335,7 +336,7 @@ where
     pub fn reveal_bob<U: Into<SwapId>>(
         self,
         swap_id: U,
-    ) -> RevealBobParameters<Pk, Qk, Rk, Sk, Addr> {
+    ) -> RevealBobParameters<Pk, Qk, Rk, Sk, Addr, Pr> {
         RevealBobParameters {
             swap_id: swap_id.into(),
             buy: self.buy,
@@ -348,6 +349,7 @@ where
             extra_accordant_keys: self.extra_accordant_keys,
             accordant_shared_keys: self.accordant_shared_keys,
             address: self.destination_address,
+            proof: self.proof.expect("Generated parameters contains proof"),
         }
     }
 }

--- a/src/swap/btcxmr/message.rs
+++ b/src/swap/btcxmr/message.rs
@@ -44,6 +44,7 @@ pub type RevealAliceParameters = message::RevealAliceParameters<
     SecretKey,
     monero::PrivateKey,
     Address,
+    DLEQProof,
 >;
 pub type RevealBobParameters = message::RevealBobParameters<
     PublicKey,
@@ -51,6 +52,5 @@ pub type RevealBobParameters = message::RevealBobParameters<
     SecretKey,
     monero::PrivateKey,
     Address,
+    DLEQProof,
 >;
-
-pub type RevealProof = message::RevealProof<DLEQProof>;

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -16,6 +16,7 @@
 
 use farcaster_core::bitcoin::segwitv0::{BuyTx, CancelTx, FundingTx, LockTx, PunishTx, RefundTx};
 use farcaster_core::bitcoin::BitcoinSegwitV0 as Btc;
+use farcaster_core::crypto::dleq::DLEQProof;
 use farcaster_core::monero::Monero as Xmr;
 use farcaster_core::swap::btcxmr::KeyManager;
 
@@ -110,9 +111,9 @@ fn execute_offline_protocol() {
 
     // Reveal
     let reveal_alice_params = alice_params.clone().reveal_alice(swap_id);
-    test_strict_ser!(reveal_alice_params, RevealAliceParameters<BPub, MPub, BPriv, MPriv, Address>);
+    test_strict_ser!(reveal_alice_params, RevealAliceParameters<BPub, MPub, BPriv, MPriv, Address, DLEQProof>);
     let reveal_bob_params = bob_params.clone().reveal_bob(swap_id);
-    test_strict_ser!(reveal_bob_params, RevealBobParameters<BPub, MPub, BPriv, MPriv, Address>);
+    test_strict_ser!(reveal_bob_params, RevealBobParameters<BPub, MPub, BPriv, MPriv, Address, DLEQProof>);
 
     assert!(commit_alice_params
         .verify_with_reveal(&commitment_engine, reveal_alice_params.clone())


### PR DESCRIPTION
Closes #278

We don't need to have two peer message types for revealing parameters and proofs. The current node implementation group them in an enum under Alice and Bob, this enum containing the old reveal params and proof and had the swap id field twice. This fixes it and will simplify node's implementation.